### PR TITLE
feat: Stripe onboarding integration on to profile page

### DIFF
--- a/frontend/src/app/Profile.tsx
+++ b/frontend/src/app/Profile.tsx
@@ -16,6 +16,7 @@ import {
   Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as WebBrowser from 'expo-web-browser'
 
 import { supabase } from '@/src/utils/supabase';
 import { JwtPayload } from '@supabase/supabase-js';
@@ -36,6 +37,8 @@ import auraGradient from '@/assets/images/profilePage/aura_gradient.png';
 import exitIcon from '@/assets/images/profilePage/exit_to_app.png';
 import carParkingIcon from '@/assets/images/carparking.png';
 import addListingIcon from '@/assets/images/addlistingimage.png';
+
+import { stripe } from '@/src/utils/stripe';
 
 const { width: screenWidth } = Dimensions.get('window');
 
@@ -98,6 +101,8 @@ export default function ProfilePage() {
   const [activeReservations, setActiveReservations] = useState<ActiveReservation[]>([]);
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [payoutSetup, setPayoutSetup] = useState(false);
+  const [stripeOnboardingLoading, setStripeOnboardingLoading] = useState(false);
 
   const nameInput = useRef<TextInput>(null);
   const emailInput = useRef<TextInput>(null);
@@ -132,6 +137,7 @@ export default function ProfilePage() {
     setUser(data as ProfileData);
     setName(data.full_name);
     setEmail(data.email);
+    setPayoutSetup(data.stripe_account_id);
     await loadVehicles(claimsResp.claims.sub);
   };
 
@@ -264,6 +270,26 @@ export default function ProfilePage() {
       setAvatarUploading(false);
     }
   };
+
+  const beginStripeOnboarding = async () => {
+    if (payoutSetup || !claims?.sub || stripeOnboardingLoading) return;
+    setStripeOnboardingLoading(true);
+
+    try {
+      await stripe.fetchStripeAccountId(claims.sub);
+      const onboardingLink = await stripe.fetchStripeAccountLink(claims.sub);
+
+      if (onboardingLink) {
+        WebBrowser.openBrowserAsync(onboardingLink);
+      } 
+    }
+    catch (err) {
+      console.log("Error starting onboarding process: " + err);
+    }
+    finally { 
+      setStripeOnboardingLoading(false); 
+    }
+  }
 
   if (!user) return <SafeAreaView style={styles.safeArea} />;
 
@@ -427,10 +453,17 @@ export default function ProfilePage() {
           )}
 
           {/* Setup Payouts banner */}
-          <View style={styles.banner}>
-            <Text style={styles.bannerText}>Setup{'\n'}Payouts</Text>
+          <TouchableOpacity 
+            style={styles.banner}
+            activeOpacity={0.85}
+            onPress={withLightHaptic(async () => beginStripeOnboarding())}
+          >
+            <Text style={styles.bannerText}>
+              { stripeOnboardingLoading ? 'Loading...' : 
+                payoutSetup ? 'Payouts\nSetup!' : 'Setup\nPayouts'}
+            </Text>
             <Image source={cardPayment} style={styles.bannerCard} resizeMode='contain' />
-          </View>
+          </TouchableOpacity>
 
           {/* Previous Reservations banner — opens history page */}
           <TouchableOpacity

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Alert,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useSegments } from 'expo-router';
@@ -22,6 +23,7 @@ import * as Haptics from 'expo-haptics';
 
 import { supabase } from '../utils/supabase';
 import { api } from '../utils/api';
+import { stripe } from '../utils/stripe';
 import { CustomFonts } from '../constants/theme';
 
 import profileDefault from '../../assets/images/temprofileicon.png';
@@ -373,9 +375,31 @@ export default function MenuBar() {
   const slideFor = (target: TabKey): 'slide_from_left' | 'slide_from_right' =>
     TAB_ORDER[target] < tabIndex ? 'slide_from_left' : 'slide_from_right';
 
-  const handlePress = (key: TabKey) => {
+  const handlePress = async (key: TabKey) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
     const animation = slideFor(key);
+
+    if (key === 'add') {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) {
+        Alert.alert('Not Logged In', 'You need to be logged in to create a listing.');
+        return;
+      }
+
+      const hasStripe = await stripe.userHasStripeAccount(session.user.id);
+      if (!hasStripe) {
+        Alert.alert(
+          'Payouts Not Set Up',
+          'Please set up payouts in your Profile before creating a listing.',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Go to Profile', onPress: () => router.push({ pathname: '/Profile', params: { animation } } as any) },
+          ]
+        );
+        return;
+      }
+    }
+
     if (key === 'profile')  router.push({ pathname: '/Profile',       params: { animation } } as any);
     else if (key === 'home')     router.push({ pathname: '/Homescreen',    params: { animation } } as any);
     else if (key === 'messages') router.push({ pathname: '/Messages',      params: { animation } } as any);


### PR DESCRIPTION
* Hooked up the setup payouts button in the profile page to link to Stripe onboarding.

IMPORTANT:
This setup is relatively flimsy, and a large part of that has to do with the fact that we are doing local development. As of right now, the Stripe account ID in the profiles table is saved upon generation of the ID, but that does not necessarily mean the user has done the proper onboarding process. That is automatically started upon pressing the payout button, but a user can preemptively leave that setup, causing an error where they have a Stripe account ID but haven't properly onboarded. A simple solution for this would be to have a data column simply called "stripe_finished_setup" that is updated once a user finishes onboarding and is redirected to a specific endpoint. Because our app is offline, we cannot actually redirect to these endpoints (ngrok doesn't work, I tried).

So in sum, make sure you complete the onboarding process when it opens upon setup.

Previous listings made by users with no Stripe ID are likely not going to work.