### PR TITLE
fix: never charge for a booking the DB will refuse, + CI to catch the next one (closes #45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,20 @@ jobs:
       # failure would otherwise surface as a wall of unrelated collection errors.
       # This step is also what catches an interpreter too old for the syntax in
       # use — the failure that cost an evening before .python-version existed.
+      #
+      # The placeholders are required, not laziness: services/supabase_client.py
+      # calls create_client() at MODULE level, so importing anything under
+      # backend/ without credentials raises "supabase_url is required". They are
+      # obvious fakes and reach no network — nothing in this job makes a request.
+      # (Worth fixing properly one day by constructing the client lazily, so the
+      # package can be imported by tests, linters and type checkers without
+      # secrets at all. Tracked as a follow-up rather than done here.)
       - name: Import the Flask app
         run: python -c "import app"
         working-directory: backend
+        env:
+          SUPABASE_URL: https://placeholder.supabase.co
+          SUPABASE_KEY: ci-placeholder-not-a-real-key
 
       # Integration tests that need a live backend SKIP with a reason rather than
       # passing vacuously; -rs prints those reasons so an all-skipped suite can

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,150 @@
+# CI for SpotOn — closes #45.
+#
+# Why this exists, concretely: a test asserting the OLD pricing rule sat RED for
+# weeks with nobody looking, which is how pricing.calculate_final_price and the
+# validate_reservation_rate trigger drifted into disagreeing about which bookings
+# are legal. That disagreement charged a renter $331.20 for a reservation the
+# database then refused. A suite nobody runs is not a safety net.
+#
+# Every job below was run locally before this was committed, so it is green on
+# arrival — CI that fails the day it lands is CI everyone learns to ignore.
+#
+# Jobs are independent (no `needs:`) so one red job never hides another's result.
+
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+# A new push to the same branch makes the previous run's answer irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: backend (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Read from .python-version so CI tests the interpreter the project
+      # DECLARES, and there is exactly one place to change it. Testing a version
+      # nobody runs is worse than not testing: it was briefly pinned to 3.9
+      # here, which is EOL and which the code cannot even import on.
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      # The app must IMPORT before any test result means anything: an import-time
+      # failure would otherwise surface as a wall of unrelated collection errors.
+      # This step is also what catches an interpreter too old for the syntax in
+      # use — the failure that cost an evening before .python-version existed.
+      - name: Import the Flask app
+        run: python -c "import app"
+        working-directory: backend
+
+      # Integration tests that need a live backend SKIP with a reason rather than
+      # passing vacuously; -rs prints those reasons so an all-skipped suite can
+      # never be mistaken for a green one.
+      - name: Run tests
+        run: python -m pytest tests/ -v -rs
+
+  frontend:
+    name: frontend (lint + jest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # `npm ci` over `npm install`: it honours the lockfile exactly, so CI can
+      # never pass on a dependency tree a teammate's checkout won't get.
+      - name: Install dependencies
+        run: npm ci
+
+      # Blocking on ERRORS only. The 46 existing warnings stay visible but
+      # non-fatal — the alternative was shipping this job red, which teaches
+      # everyone to ignore it. Ratchet later with `-- --max-warnings N`,
+      # lowering N as the backlog clears.
+      - name: Lint
+        run: npm run lint
+
+      # --ci fails on missing snapshots instead of writing them;
+      # --passWithNoTests keeps the job honest if the suite is ever emptied
+      # (silence must not read as success).
+      - name: Jest
+        run: npm test -- --ci --passWithNoTests
+
+  migrations:
+    name: migrations (naming + order)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Timestamp order is not cosmetic. `supabase db push` refuses to insert a
+      # migration dated before one already applied ("found local migration files
+      # to be inserted before the last migration"), so two people authoring on
+      # separate branches can produce a pair that only breaks once BOTH are
+      # merged — on someone else's machine, days later. Catching it per-branch
+      # costs a second.
+      - name: Filenames are timestamp-ordered and unique
+        working-directory: supabase/migrations
+        run: |
+          ls *.sql | sort -c || {
+            echo "::error::migration filenames are not in timestamp order"; exit 1; }
+          dupes=$(ls *.sql | cut -d_ -f1 | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error::duplicate migration timestamps: $dupes"; exit 1
+          fi
+          echo "$(ls *.sql | wc -l | tr -d ' ') migrations, ordered and unique"
+
+      # Cheap structural smoke test: catches an unbalanced BEGIN/COMMIT or a
+      # stray $$ delimiter before it ever reaches a database.
+      - name: Migrations are structurally complete
+        working-directory: supabase/migrations
+        run: |
+          fail=0
+          for f in *.sql; do
+            begins=$(grep -ciE '^[[:space:]]*BEGIN[[:space:]]*;' "$f" || true)
+            commits=$(grep -ciE '^[[:space:]]*COMMIT[[:space:]]*;' "$f" || true)
+            if [ "$begins" -ne "$commits" ]; then
+              echo "::error file=supabase/migrations/$f::BEGIN/COMMIT mismatch ($begins/$commits)"
+              fail=1
+            fi
+            dollars=$(grep -o '[$][$]' "$f" | wc -l | tr -d ' ')
+            if [ $((dollars % 2)) -ne 0 ]; then
+              echo "::error file=supabase/migrations/$f::odd number of dollar-quote delimiters"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      # NOT DONE HERE, deliberately: actually APPLYING the migrations. The first
+      # one (20260421001633_remote_schema.sql) is a `supabase db pull` dump that
+      # references platform schemas and objects it never creates, so replaying it
+      # on a bare Postgres image does not work — attempted, and it dies on
+      # `schema "extensions" does not exist` plus a missing public.listing_images
+      # well before reaching any of our own SQL.
+      #
+      # The right way is the Supabase CLI, which is what we already run locally:
+      #     - uses: supabase/setup-cli@v1
+      #     - run: supabase db start     # applies every migration in order
+      # Worth adding, but it needs a real run to verify rather than a guess, so
+      # it is left as a follow-up instead of shipped untested. Until then the
+      # reservation rules are covered by tests/backend, which exercises the
+      # pricing engine and the pre-charge validation path.

--- a/backend/services/stripe_client.py
+++ b/backend/services/stripe_client.py
@@ -139,6 +139,52 @@ def _refund_stranded_payment(payment_intent_id: str, reason: str) -> str:
         return "refund_failed"
 
 
+# Raw SQLSTATE strings must never reach a renter's screen. finalize's catch-all
+# formats DB failures as 'db_<SQLSTATE>: <SQLERRM>', which is how a customer ended
+# up reading "db_P0001: Daily bookings not supported for this listing" in a dialog.
+# P0001 is merely "a trigger of ours raised" — the text after it IS ours and is
+# human, so it can be surfaced; class-23 messages are Postgres internals about
+# constraint names and never can be.
+_OUR_RAISE = re.compile(r"^db_P0001:\s*(.+)$", re.S)
+_CONSTRAINT_VIOLATION = re.compile(r"^db_23[0-9A-Z]{3}:")
+
+
+def _finalize_reason(error: str) -> str:
+    """One clause naming what went wrong, in words a renter understands."""
+    if not error:
+        return "We could not create your reservation."
+    if error.startswith("slot_unavailable") or _CONSTRAINT_VIOLATION.match(error):
+        return "That spot was just booked by someone else."
+    if error.startswith("missing_metadata"):
+        return "We lost track of this booking's details."
+    ours = _OUR_RAISE.match(error)
+    if ours:
+        reason = ours.group(1).strip()
+        return reason if reason.endswith(".") else reason + "."
+    return "We could not create your reservation."
+
+
+def _finalize_user_message(error: str, *, refunded: bool | None) -> str:
+    """The whole message shown to the renter.
+
+    refunded=None means the failure is RETRYABLE: the payment stands and the
+    webhook will finish the booking, so telling the user anything alarming (or
+    inviting them to pay again) would be wrong.
+    """
+    if refunded is None:
+        return (
+            "Your payment went through and we're still confirming this booking. "
+            "It should appear in your reservations shortly — please don't pay again."
+        )
+    reason = _finalize_reason(error)
+    if refunded:
+        return f"{reason} You have not been charged — the payment was refunded."
+    return (
+        f"{reason} We could not issue the refund automatically, so please contact "
+        "support and we'll return the payment."
+    )
+
+
 def create_booking_payment(listing_id: str, renter_id: str, vehicle_id: str,
                            start_time: str, end_time: str):
     """
@@ -506,24 +552,25 @@ def finalize_booking(payment_intent_id: str):
 
     if outcome.get("error"):
         error = outcome["error"]
-        # 409 signals "payment fine, reservation could not be created". For a
-        # TERMINAL failure the money goes back automatically and the client is
-        # told so, instead of being sent to support with an error code.
+        # 409 signals "payment fine, reservation could not be created". Every
+        # branch returns a `message` fit to display and keeps the raw string in
+        # `detail` for logs and support — the UI should never render a SQLSTATE.
         if _is_terminal_finalize_error(error):
             disposition = _refund_stranded_payment(pi.get("id"), error)
             refunded = disposition in ("refunded", "already_refunded")
             return jsonify({
-                "error": error,
+                "detail": error,
                 "refunded": refunded,
                 "refund_status": disposition,
-                "message": (
-                    "You have not been charged — the payment was refunded."
-                    if refunded else
-                    "Your reservation could not be created and the automatic refund "
-                    "failed. Contact support with this message."
-                ),
+                "message": _finalize_user_message(error, refunded=refunded),
             }), 409
-        return jsonify({"error": error, "refunded": False, "refund_status": "retryable"}), 409
+        # Retryable: the webhook will finish this booking, so the payment stands.
+        return jsonify({
+            "detail": error,
+            "refunded": False,
+            "refund_status": "retryable",
+            "message": _finalize_user_message(error, refunded=None),
+        }), 409
     return jsonify({"reservationId": outcome["reservation_id"]}), 200
 
 

--- a/backend/services/stripe_client.py
+++ b/backend/services/stripe_client.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 import traceback
 import stripe
 from flask import jsonify
@@ -56,6 +57,88 @@ def _sheet_response(payment_intent_client_secret, customer_session_secret, custo
 HOLD_TTL_MINUTES = 5
 
 
+def _reservation_validation_error(listing_id: str, start_time: str, end_time: str):
+    """Ask the DATABASE whether this reservation may exist — before charging.
+
+    Calls the same reservation_validation_error() that the BEFORE INSERT trigger
+    raises, so this pre-charge check cannot drift from the enforcement. That
+    drift is precisely what charged a renter $331.20 for a booking the trigger
+    then refused (see migration 20260730005125).
+
+    Returns the reason string, or None when the booking is allowed. Failure to
+    REACH the check also returns None, deliberately: the trigger is still the
+    backstop, and refusing every booking because a speculative query failed
+    would be worse than falling through to it.
+    """
+    try:
+        result = supabase.rpc("reservation_validation_error", {
+            "p_listing_id": listing_id,
+            "p_start_time": start_time,
+            "p_end_time": end_time,
+        }).execute()
+    except Exception as err:  # noqa: BLE001
+        print(f"[stripe] pre-charge validation unavailable for {listing_id}: {err}")
+        return None
+    reason = getattr(result, "data", None)
+    if isinstance(reason, list):
+        reason = reason[0] if reason else None
+    if isinstance(reason, dict):  # some client versions wrap scalar returns
+        reason = next(iter(reason.values()), None)
+    return reason or None
+
+
+# SQLSTATEs that mean "this reservation can never be created", as opposed to
+# "try again later". P0001 is a deliberate RAISE from our own triggers (a
+# business rule); class 23 are integrity violations (unique, FK, exclusion).
+# Both are terminal, so a payment already captured against one must be refunded
+# rather than left for someone to notice in a log. Anything else — a dropped
+# connection, an empty RPC response, an unhandled crash — may succeed on the
+# webhook's retry, and refunding it would cancel a booking about to work.
+_TERMINAL_ERROR_PREFIXES = ("slot_unavailable", "missing_metadata")
+
+
+def _is_terminal_finalize_error(message: str) -> bool:
+    if not message:
+        return False
+    if message.startswith(_TERMINAL_ERROR_PREFIXES):
+        return True
+    # SQLSTATEs are 5 alphanumeric chars, not 5 digits: class 23 includes 23505
+    # (unique), 23503 (FK) AND 23P01 (exclusion — the double-booking one), so a
+    # \d{3} tail silently missed exactly the case that matters most here.
+    return bool(re.match(r"^db_(P0001|23[0-9A-Z]{3}):", message))
+
+
+def _refund_stranded_payment(payment_intent_id: str, reason: str) -> str:
+    """Refund a captured payment whose reservation could not be created.
+
+    The renter's money must not depend on someone reading a log line. Idempotent
+    two ways: an existing refund short-circuits, and the create call carries an
+    idempotency key, so the client path and the webhook path racing each other
+    cannot double-refund.
+
+    Stripe's refund `reason` enum has no "our bug" member; requested_by_customer
+    is the conventional choice for a merchant-initiated make-good, and the real
+    cause rides in metadata for reconciliation.
+    """
+    if not payment_intent_id:
+        return "no_payment_intent"
+    try:
+        existing = stripe.Refund.list(payment_intent=payment_intent_id, limit=1)
+        if getattr(existing, "data", None):
+            return "already_refunded"
+        stripe.Refund.create(
+            payment_intent=payment_intent_id,
+            reason="requested_by_customer",
+            metadata={"spoton_refund_cause": str(reason)[:400]},
+            idempotency_key=f"spoton-stranded-{payment_intent_id}",
+        )
+        return "refunded"
+    except Exception as err:  # noqa: BLE001 — the original failure still wins
+        print(f"[stripe] REFUND FAILED for {payment_intent_id} ({reason}): {err}")
+        traceback.print_exc()
+        return "refund_failed"
+
+
 def create_booking_payment(listing_id: str, renter_id: str, vehicle_id: str,
                            start_time: str, end_time: str):
     """
@@ -83,6 +166,13 @@ def create_booking_payment(listing_id: str, renter_id: str, vehicle_id: str,
 
     if renter_id == owner_id:
         return jsonify({"error": "You can't reserve your own listing.", "code": "self_booking"}), 400
+
+    # Refuse anything the DB would refuse, BEFORE any money moves. Same function
+    # the insert trigger enforces, so a rule can never reject a booking only
+    # after the renter's card has been charged.
+    blocked = _reservation_validation_error(listing_id, start_time, end_time)
+    if blocked:
+        return jsonify({"error": blocked, "code": "invalid_booking"}), 400
 
     try:
         breakdown = calculate_final_price(listing, start_time, end_time)
@@ -371,13 +461,19 @@ def _finalize_reservation_from_pi(pi) -> dict:
 def _on_payment_succeeded(pi: dict):
     """Webhook path — reliable backstop that creates the reservation on payment."""
     outcome = _finalize_reservation_from_pi(pi)
-    if outcome.get("error") == "missing_metadata":
-        print(f"[stripe] payment {pi['id']} missing booking metadata; skipping finalize")
-    elif outcome.get("error"):
-        # Refund-on-conflict intentionally deferred: log loudly so a
-        # charged-but-unbooked payment is visible until it's built out.
-        print(f"[stripe] WARNING payment {pi['id']} succeeded but reservation "
-              f"not created ({outcome['error']}); needs manual review")
+    error = outcome.get("error")
+    if error and _is_terminal_finalize_error(error):
+        # Terminal: the reservation can never be created, so the capture must not
+        # stand. Refund instead of leaving it for manual review (this is the
+        # "refund-on-conflict" that used to be deferred here).
+        disposition = _refund_stranded_payment(pi.get("id"), error)
+        print(f"[stripe] payment {pi.get('id')} could not be booked ({error}) "
+              f"-> refund {disposition}")
+    elif error:
+        # Non-terminal: may succeed on a later retry. Refunding here would cancel
+        # a booking that is about to work, so stay loud instead.
+        print(f"[stripe] WARNING payment {pi.get('id')} succeeded but reservation "
+              f"not created ({error}); retryable — needs review if it persists")
     else:
         print(f"[stripe] payment succeeded for PI {pi['id']} -> reservation {outcome['reservation_id']} (held)")
 
@@ -409,8 +505,25 @@ def finalize_booking(payment_intent_id: str):
         return jsonify({"error": f"finalize_unhandled: {e}"}), 500
 
     if outcome.get("error"):
-        # 409 signals "payment fine, reservation could not be created" — the client shows the message.
-        return jsonify({"error": outcome["error"]}), 409
+        error = outcome["error"]
+        # 409 signals "payment fine, reservation could not be created". For a
+        # TERMINAL failure the money goes back automatically and the client is
+        # told so, instead of being sent to support with an error code.
+        if _is_terminal_finalize_error(error):
+            disposition = _refund_stranded_payment(pi.get("id"), error)
+            refunded = disposition in ("refunded", "already_refunded")
+            return jsonify({
+                "error": error,
+                "refunded": refunded,
+                "refund_status": disposition,
+                "message": (
+                    "You have not been charged — the payment was refunded."
+                    if refunded else
+                    "Your reservation could not be created and the automatic refund "
+                    "failed. Contact support with this message."
+                ),
+            }), 409
+        return jsonify({"error": error, "refunded": False, "refund_status": "retryable"}), 409
     return jsonify({"reservationId": outcome["reservation_id"]}), 200
 
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -582,7 +582,7 @@ export default function MenuBar() {
         </Text>
         <Text style={[styles.addInfoBody, { fontSize: W * 0.036, lineHeight: W * 0.052, marginBottom: W * 0.055 }]}>
           You can create your listing and start earning right away — no business account needed. When your first booking
-          comes in, we'll ask for a few quick payout details so your money goes straight to your bank.
+          comes in, we&apos;ll ask for a few quick payout details so your money goes straight to your bank.
         </Text>
 
         <TouchableOpacity

--- a/frontend/src/components/ProfilePageComponents/EditableProfileCard.tsx
+++ b/frontend/src/components/ProfilePageComponents/EditableProfileCard.tsx
@@ -27,10 +27,12 @@ type CardProps = {
 }
 
 export default function EditableProfileCard({ name, setName, rating }: CardProps) {
-  if (!setName || !rating) {
-    return null;
-  }
-
+  // Hooks must run before any early return: React matches them up by call
+  // ORDER across renders, so a return that skips them makes one render call
+  // three hooks and the next call none, which throws "rendered fewer hooks
+  // than expected" and unmounts the card. Reachable today — `!rating` is true
+  // for a rating of 0, i.e. every brand-new user, so the component bailed out
+  // early and then crashed as soon as a real rating arrived.
   const inputArea = useRef<TextInput>(null);
 
   const [editing, setEditing] = useState(false);
@@ -40,6 +42,14 @@ export default function EditableProfileCard({ name, setName, rating }: CardProps
       inputArea.current?.focus();
     }
   }, [editing]);
+
+  // Same condition as before, just moved below the hooks so rendering is
+  // unchanged. NOTE: `!rating` also hides the card for a legitimate 0 rating —
+  // left as-is because whether a new user should see their own card is a
+  // product call, not a lint fix.
+  if (!setName || !rating) {
+    return null;
+  }
 
   const editUsername = () => {
     setEditing(!editing);

--- a/supabase/migrations/20260730005125_align_reservation_rate_validation.sql
+++ b/supabase/migrations/20260730005125_align_reservation_rate_validation.sql
@@ -1,0 +1,121 @@
+-- Fix the "payment succeeded, booking not confirmed" class of bug by giving the
+-- reservation rules ONE implementation that both the database and the backend
+-- call, and by aligning that rule with the pricing engine.
+--
+-- THE BUG. Two implementations of "which durations may be booked" disagreed:
+--
+--   * backend/utils/pricing.py (calculate_final_price) picks the best tier
+--     available and FALLS BACK — no daily_rate? charge hourly. It only refuses
+--     when the listing has no usable rate at all.
+--   * validate_reservation_rate() required the tier matching the duration to
+--     exist: >= 9h demanded daily_rate, >= 7d demanded weekly_rate, >= 4w
+--     demanded monthly_rate, else demanded hourly_rate.
+--
+-- Money moves in create_booking_payment (which prices with Python), while the
+-- trigger only fires later, at finalize_paid_reservation's INSERT. So a booking
+-- Python priced happily was rejected AFTER Stripe captured: the renter is
+-- charged, no reservation row exists, and finalize's `WHEN OTHERS` handler
+-- surfaces 'db_P0001: <the trigger's message>' to the app.
+--
+-- Two live instances, both reproduced against this schema:
+--   A. 96h booking on a $3/hr listing with daily_rate NULL. Python: 96 * 3 =
+--      $288 + 15% = $331.20 captured. Trigger: 'Daily bookings not supported'.
+--   B. a plain 2h booking on a legacy listing where only price_per_hour is set
+--      and hourly_rate is NULL. Python falls back to price_per_hour and prices
+--      it; the trigger read hourly_rate only and raised 'Hourly bookings not
+--      supported'. price_per_hour is NOT NULL on listings while hourly_rate is
+--      nullable, so this shape is not hypothetical.
+--
+-- THE RULING (Ehan, 2026-07-26): "users should be able to still reserve for
+-- more than a day, they would just be charged with the hourly rate", and no cap
+-- on how long an hourly booking may run — "if a daily rate is available then
+-- the app automatically switches to that anyways" (which
+-- _compute_hourly_with_day_cap already does). So the tier-must-exist rule was
+-- the wrong side, not the pricing engine.
+--
+-- WHY NOT JUST DROP THE TRIGGER. Its last arm is a real guard: a reservation
+-- against a listing with no usable rate would store a price derived from
+-- nothing. That case is kept. What changes is that it now rejects exactly when
+-- the pricing engine would refuse to price.
+--
+-- WHY A SHARED FUNCTION. The root cause was two copies of one rule drifting
+-- apart with nothing forcing them to move together. reservation_validation_error
+-- is now the single definition: the trigger raises whatever it returns, and the
+-- backend calls the SAME function over RPC before it creates a PaymentIntent
+-- (see create_booking_payment). Any rule added here is therefore enforced
+-- before the card is charged, not after — which is the only ordering that
+-- cannot strand a paid renter.
+
+BEGIN;
+
+-- Returns NULL when the reservation is allowed, or a human-readable reason why
+-- it is not. STABLE and side-effect free so it is safe to call speculatively
+-- from the pre-charge path.
+--
+-- p_start_time / p_end_time are accepted even though today's rules only depend
+-- on the listing's rate columns: duration-dependent rules (availability
+-- windows, max-duration caps) belong here next, and taking the parameters now
+-- means both callers pick those rules up without another signature change.
+CREATE OR REPLACE FUNCTION public.reservation_validation_error(
+  p_listing_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz
+) RETURNS text AS $$
+DECLARE
+  listing_row RECORD;
+  effective_hourly numeric;
+BEGIN
+  IF p_end_time <= p_start_time THEN
+    RETURN 'end_time must be after start_time';
+  END IF;
+
+  SELECT * INTO listing_row FROM public.listings WHERE id = p_listing_id;
+  IF NOT FOUND THEN
+    RETURN 'Listing not found';
+  END IF;
+
+  -- Same precedence as pricing.calculate_final_price: hourly_rate wins, then
+  -- the legacy price_per_hour column.
+  effective_hourly := COALESCE(listing_row.hourly_rate, listing_row.price_per_hour);
+
+  -- Reject only what the pricing engine itself would refuse to price. Any
+  -- duration is bookable as long as SOME rate exists: the engine selects the
+  -- cheapest applicable tier and caps hourly runs at the daily rate when set.
+  IF effective_hourly IS NULL
+     AND listing_row.daily_rate IS NULL
+     AND listing_row.weekly_rate IS NULL
+     AND listing_row.monthly_rate IS NULL
+  THEN
+    RETURN 'No rates available for this listing';
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION public.reservation_validation_error(uuid, timestamptz, timestamptz) IS
+  'Single source of truth for "may this reservation exist". Returns NULL if allowed, else the reason. Called by the validate_reservation_rate trigger (which raises it) AND by the backend before creating a PaymentIntent, so no rule can reject a booking only after the renter has been charged. Mirrors pricing.calculate_final_price, which falls back across tiers rather than requiring the tier matching the duration.';
+
+GRANT EXECUTE ON FUNCTION public.reservation_validation_error(uuid, timestamptz, timestamptz)
+  TO authenticated, service_role, anon;
+
+-- The trigger becomes a thin raiser over the shared rule.
+CREATE OR REPLACE FUNCTION public.validate_reservation_rate()
+RETURNS TRIGGER AS $$
+DECLARE
+  validation_error text;
+BEGIN
+  validation_error := public.reservation_validation_error(
+    NEW.listing_id, NEW.start_time, NEW.end_time
+  );
+  IF validation_error IS NOT NULL THEN
+    RAISE EXCEPTION '%', validation_error;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION public.validate_reservation_rate() IS
+  'Last-line enforcement of reservation_validation_error(). Deliberately holds no rules of its own: money is captured before this fires, so anything enforced ONLY here strands a paid renter with no reservation.';
+
+COMMIT;

--- a/tests/backend/test_notification_triggers.py
+++ b/tests/backend/test_notification_triggers.py
@@ -1,0 +1,254 @@
+"""Tests for the three notification triggers (task: week of 2026-07-29).
+
+Asked: "they should give notifications whenever a lister purchases a listing,
+its time begins, and its time ends. (Needs to be tested)".
+
+Tested at this layer on purpose — the app needs a dev build on a device, so the
+only way to check these deterministically is against the service functions with
+the Supabase client and Expo transport faked.
+
+WHAT THESE PIN
+  * booking notifies BOTH sides, once each, with the renter/lister roles right;
+  * start and end notify both sides;
+  * the (reservation_id, event_key) unique constraint is what makes the webhook
+    and the client calling finalize both safe — a second run sends nothing;
+  * a recipient with no push token still records an event, so the sweep does not
+    retry them forever.
+
+KNOWN GAP THIS DOCUMENTS (see test_event_is_recorded_sent_before_the_push_is_attempted):
+_send_once inserts the event with status 'sent' and only then calls send_push,
+which is documented "never raises into the caller". So a push that fails in
+transport is recorded as sent and never retried: notification_events records
+INTENT, not delivery. That is a deliberate trade for dedupe (claim-then-send is
+the right order), but the status value is currently optimistic — worth a
+'pending' -> 'sent'/'failed' settle if delivery ever needs to be provable.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+RENTER = "11111111-1111-4111-8111-111111111111"
+OWNER = "22222222-2222-4222-8222-222222222222"
+RES_ID = "33333333-3333-4333-8333-333333333333"
+
+
+class _FakeDB:
+    """Stands in for the Supabase client: profiles, reservations, and a
+    notification_events table with the real UNIQUE(reservation_id, event_key)."""
+
+    def __init__(self, tokens=None):
+        self.events = []          # rows that "landed"
+        self.pushes = []          # (token, title, body, data)
+        self.tokens = tokens if tokens is not None else {RENTER: "ExpoTok[renter]",
+                                                         OWNER: "ExpoTok[owner]"}
+
+    # -- query surface -------------------------------------------------------
+    def table(self, name):
+        return _FakeTable(self, name)
+
+    # -- helpers -------------------------------------------------------------
+    def _profile(self, uid):
+        if uid not in (RENTER, OWNER):
+            return None
+        return {"id": uid, "expo_push_token": self.tokens.get(uid)}
+
+    def _reservation(self):
+        return {
+            "id": RES_ID,
+            "renter_id": RENTER,
+            "listing_id": "listing-1",
+            "start_time": "2026-08-01T10:00:00+00:00",
+            "end_time": "2026-08-01T12:00:00+00:00",
+            "total_price": 6.90,
+            "host_payout": 6.00,
+            "status": "confirmed",
+            "listings": {"owner_id": OWNER, "address": "1 Test St"},
+        }
+
+
+class _FakeTable:
+    def __init__(self, db, name):
+        self.db, self.name = db, name
+        self._payload = None
+        self._filters = {}
+
+    def select(self, *_a, **_k):
+        return self
+
+    def insert(self, payload):
+        self._payload = payload
+        return self
+
+    def eq(self, col, val):
+        self._filters[col] = val
+        return self
+
+    def single(self):
+        return self
+
+    def maybe_single(self):
+        return self
+
+    def execute(self):
+        if self.name == "notification_events" and self._payload is not None:
+            key = (self._payload["reservation_id"], self._payload["event_key"])
+            if any((e["reservation_id"], e["event_key"]) == key for e in self.db.events):
+                # Exactly what Postgres raises through supabase-py.
+                raise RuntimeError(
+                    'duplicate key value violates unique constraint '
+                    '"notification_events_reservation_id_event_key_key" (23505)'
+                )
+            self.db.events.append(self._payload)
+            return types.SimpleNamespace(data=[self._payload])
+        if self.name == "profiles":
+            return types.SimpleNamespace(data=self.db._profile(self._filters.get("id")))
+        if self.name == "reservations":
+            return types.SimpleNamespace(data=self.db._reservation())
+        return types.SimpleNamespace(data=None)
+
+
+@pytest.fixture
+def notifications(monkeypatch):
+    """Import services.notifications with the DB and Expo transport faked."""
+    db = _FakeDB()
+
+    supabase_mod = types.ModuleType("services.supabase_client")
+    supabase_mod.supabase = db
+    monkeypatch.setitem(sys.modules, "services.supabase_client", supabase_mod)
+
+    monkeypatch.delitem(sys.modules, "services.notifications", raising=False)
+    monkeypatch.delitem(sys.modules, "services.payouts", raising=False)
+    import services.notifications as notif
+
+    monkeypatch.setattr(notif, "supabase", db)
+    monkeypatch.setattr(notif, "send_push",
+                        lambda token, title, body, data: db.pushes.append((token, title, body, data)))
+    notif._db = db  # test handle
+    return notif
+
+
+def _keys(db):
+    return sorted(e["event_key"] for e in db.events)
+
+
+# ── trigger 1: a lister's spot is purchased ────────────────────────────────────
+
+def test_booking_notifies_both_sides_once(notifications):
+    db = notifications._db
+    result = notifications.send_booking_notifications(RES_ID)
+
+    assert result == {"booked_renter": True, "booked_lister": True}
+    assert _keys(db) == ["booked_lister", "booked_renter"]
+    assert len(db.pushes) == 2
+
+    by_recipient = {e["recipient_id"]: e for e in db.events}
+    assert by_recipient[RENTER]["data"]["role"] == "renter"
+    assert by_recipient[OWNER]["data"]["role"] == "lister"
+    # The lister's copy must say a payment happened — that's the asked-for signal.
+    assert "Payment was made" in by_recipient[OWNER]["body"]
+
+
+def test_booking_is_not_sent_twice(notifications):
+    """finalize_booking (client) and the payment_intent.succeeded webhook both
+    call this for the same reservation. The second must be a no-op."""
+    db = notifications._db
+    notifications.send_booking_notifications(RES_ID)
+    second = notifications.send_booking_notifications(RES_ID)
+
+    assert second == {"booked_renter": False, "booked_lister": False}
+    assert len(db.events) == 2, "unique constraint must stop a duplicate row"
+    assert len(db.pushes) == 2, "and no second phone notification"
+
+
+# ── triggers 2 and 3: time begins, time ends ──────────────────────────────────
+
+def test_start_notifies_both_sides_once(notifications):
+    db = notifications._db
+    res = db._reservation()
+
+    assert notifications._send_start_notifications(res) == 2
+    assert _keys(db) == ["started_lister", "started_renter"]
+    assert notifications._send_start_notifications(res) == 0, "sweep reruns must not resend"
+    assert len(db.pushes) == 2
+
+
+def test_end_notifies_both_sides_once(notifications):
+    db = notifications._db
+    res = db._reservation()
+
+    assert notifications._send_end_notifications(res) == 2
+    assert _keys(db) == ["ended_lister", "ended_renter"]
+    assert notifications._send_end_notifications(res) == 0
+    assert len(db.pushes) == 2
+
+
+def test_start_and_end_are_independent_events(notifications):
+    """Distinct event_keys, so 'started' never suppresses 'ended'."""
+    db = notifications._db
+    res = db._reservation()
+    notifications._send_start_notifications(res)
+    notifications._send_end_notifications(res)
+
+    assert _keys(db) == ["ended_lister", "ended_renter",
+                         "started_lister", "started_renter"]
+
+
+# ── recipients without a device ───────────────────────────────────────────────
+
+def test_missing_push_token_records_the_event_and_sends_nothing(monkeypatch):
+    """A tokenless recipient must still consume its event_key, or every sweep
+    would retry them forever. Status says skipped_no_token, not sent."""
+    db = _FakeDB(tokens={RENTER: None, OWNER: "ExpoTok[owner]"})
+
+    supabase_mod = types.ModuleType("services.supabase_client")
+    supabase_mod.supabase = db
+    monkeypatch.setitem(sys.modules, "services.supabase_client", supabase_mod)
+    monkeypatch.delitem(sys.modules, "services.notifications", raising=False)
+    monkeypatch.delitem(sys.modules, "services.payouts", raising=False)
+    import services.notifications as notif
+    monkeypatch.setattr(notif, "supabase", db)
+    monkeypatch.setattr(notif, "send_push",
+                        lambda t, ti, b, d: db.pushes.append((t, ti, b, d)))
+
+    result = notif.send_booking_notifications(RES_ID)
+
+    assert result == {"booked_renter": True, "booked_lister": True}
+    statuses = {e["recipient_id"]: e["status"] for e in db.events}
+    assert statuses[RENTER] == "skipped_no_token"
+    assert statuses[OWNER] == "sent"
+
+
+# ── the documented gap ────────────────────────────────────────────────────────
+
+def test_event_is_recorded_sent_before_the_push_is_attempted(notifications):
+    """Pins current behaviour, and names the limitation.
+
+    The row is written (status 'sent') BEFORE send_push runs, and send_push is
+    documented never to raise. Claim-then-send is the correct ORDER for dedupe —
+    it is what stops double-sending — but it means a transport failure is
+    recorded as 'sent' and never retried, so this table proves intent, not
+    delivery. If delivery ever has to be provable, settle the row after the
+    send ('pending' -> 'sent'/'failed') instead of asserting it up front.
+    """
+    db = notifications._db
+
+    def _exploding_push(*_a, **_k):
+        raise RuntimeError("expo unreachable")
+
+    # send_push itself swallows in production; simulate the transport dying
+    # underneath it to show the recorded status does not reflect the outcome.
+    import services.notifications as notif
+    original = notif.send_push
+    notif.send_push = lambda t, ti, b, d: None  # what production does: silent
+    try:
+        notifications.send_booking_notifications(RES_ID)
+    finally:
+        notif.send_push = original
+
+    assert [e["status"] for e in db.events] == ["sent", "sent"]
+    assert db.pushes == [], "nothing actually went out, yet both rows say 'sent'"

--- a/tests/backend/test_stranded_payment_refund.py
+++ b/tests/backend/test_stranded_payment_refund.py
@@ -1,0 +1,317 @@
+"""Regression tests for the "payment succeeded, booking not confirmed" class.
+
+A renter was charged $331.20 for a booking the DB then refused, and the code's
+own comment admitted the recovery was "intentionally deferred: log loudly ...
+needs manual review". These pin the two halves of the fix:
+
+  1. terminal failures are classified as terminal, retryable ones are not, and
+  2. a terminal failure refunds automatically, exactly once.
+
+No Stripe network calls and no device: the refund path's Stripe surface is
+faked and the Supabase client (which needs live env vars) is stubbed. Run with
+backend/.venv, which the README already prescribes:
+    backend/.venv/bin/python -m pytest tests/
+The app itself needs a dev build on a phone, which is exactly why these tests
+live at this layer instead.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+
+@pytest.fixture
+def stripe_client(monkeypatch):
+    """Import services.stripe_client with its heavy deps stubbed out.
+
+    supabase_client builds a live client at import time and stripe/dotenv may be
+    absent; none of that is what these tests are about.
+    """
+    for name, attrs in {
+        "services.supabase_client": {"supabase": types.SimpleNamespace()},
+        "services.payouts": {"_parse_ts": lambda *_a: None,
+                             "release_pending_for_account": lambda *_a: 0},
+        "services.notifications": {"send_booking_notifications": lambda *_a: {}},
+    }.items():
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.delitem(sys.modules, "services.stripe_client", raising=False)
+    import services.stripe_client as sc
+    return sc
+
+
+# ── classification: terminal vs retryable ──────────────────────────────────────
+
+@pytest.mark.parametrize("message", [
+    "db_P0001: Daily bookings not supported for this listing",  # the real one
+    "db_P0001: No rates available for this listing",
+    "db_23505: duplicate key value violates unique constraint",
+    "db_23P01: conflicting key value violates exclusion constraint",
+    "slot_unavailable",
+    "missing_metadata: vehicle_id",
+])
+def test_terminal_errors_are_classified_terminal(stripe_client, message):
+    """These can never succeed on retry, so the capture must be given back."""
+    assert stripe_client._is_terminal_finalize_error(message) is True
+
+
+@pytest.mark.parametrize("message", [
+    "db_error: connection reset by peer",
+    "db_08006: could not connect to server",
+    "rpc_empty_response",
+    "rpc_no_reservation_id",
+    "finalize_crashed: KeyError('metadata')",
+    "",
+    None,
+])
+def test_retryable_errors_are_not_refunded(stripe_client, message):
+    """Refunding a transient failure would cancel a booking that is about to
+    work — the webhook retry is the recovery path for these."""
+    assert stripe_client._is_terminal_finalize_error(message) is False
+
+
+# ── the refund itself ──────────────────────────────────────────────────────────
+
+class _FakeRefund:
+    """Minimal stand-in for stripe.Refund, recording what it was asked to do."""
+
+    def __init__(self, existing=None, explode=False):
+        self.existing = existing or []
+        self.explode = explode
+        self.created = []
+
+    def list(self, payment_intent=None, limit=None):
+        return types.SimpleNamespace(data=list(self.existing))
+
+    def create(self, **kwargs):
+        if self.explode:
+            raise RuntimeError("stripe is down")
+        self.created.append(kwargs)
+        return types.SimpleNamespace(id="re_test")
+
+
+def test_terminal_failure_refunds_the_payment(stripe_client, monkeypatch):
+    fake = _FakeRefund()
+    monkeypatch.setattr(stripe_client.stripe, "Refund", fake)
+
+    result = stripe_client._refund_stranded_payment(
+        "pi_331", "db_P0001: Daily bookings not supported for this listing"
+    )
+
+    assert result == "refunded"
+    assert len(fake.created) == 1
+    call = fake.created[0]
+    assert call["payment_intent"] == "pi_331"
+    # The cause must survive into Stripe for reconciliation, not just the log.
+    assert "Daily bookings not supported" in call["metadata"]["spoton_refund_cause"]
+    # Idempotency key keyed on the PI is what stops the client path and the
+    # webhook path from both refunding the same capture.
+    assert call["idempotency_key"] == "spoton-stranded-pi_331"
+
+
+def test_refund_is_not_issued_twice(stripe_client, monkeypatch):
+    """The client call and the webhook both run this path for the same payment."""
+    fake = _FakeRefund(existing=[types.SimpleNamespace(id="re_already")])
+    monkeypatch.setattr(stripe_client.stripe, "Refund", fake)
+
+    result = stripe_client._refund_stranded_payment("pi_331", "slot_unavailable")
+
+    assert result == "already_refunded"
+    assert fake.created == [], "must not create a second refund"
+
+
+def test_refund_failure_is_reported_not_raised(stripe_client, monkeypatch):
+    """A failed refund must not turn into a 500 that hides the original problem —
+    the caller still has to tell the renter something true."""
+    fake = _FakeRefund(explode=True)
+    monkeypatch.setattr(stripe_client.stripe, "Refund", fake)
+
+    result = stripe_client._refund_stranded_payment("pi_331", "slot_unavailable")
+
+    assert result == "refund_failed"
+
+
+def test_missing_payment_intent_is_handled(stripe_client, monkeypatch):
+    fake = _FakeRefund()
+    monkeypatch.setattr(stripe_client.stripe, "Refund", fake)
+    assert stripe_client._refund_stranded_payment(None, "slot_unavailable") == "no_payment_intent"
+    assert fake.created == []
+
+
+# ── the pre-charge gate ────────────────────────────────────────────────────────
+
+def test_pre_charge_check_returns_the_db_reason(stripe_client, monkeypatch):
+    """create_booking_payment consults the SAME rule the trigger enforces, so a
+    rejected booking never reaches Stripe at all."""
+    class _RPC:
+        def execute(self):
+            return types.SimpleNamespace(data="No rates available for this listing")
+
+    monkeypatch.setattr(stripe_client.supabase, "rpc",
+                        lambda name, params: _RPC(), raising=False)
+
+    reason = stripe_client._reservation_validation_error(
+        "listing-1", "2026-08-01T10:00:00+00:00", "2026-08-01T12:00:00+00:00"
+    )
+    assert reason == "No rates available for this listing"
+
+
+def test_pre_charge_check_allows_when_db_returns_null(stripe_client, monkeypatch):
+    class _RPC:
+        def execute(self):
+            return types.SimpleNamespace(data=None)
+
+    monkeypatch.setattr(stripe_client.supabase, "rpc",
+                        lambda name, params: _RPC(), raising=False)
+
+    assert stripe_client._reservation_validation_error(
+        "listing-1", "2026-08-01T10:00:00+00:00", "2026-08-01T12:00:00+00:00"
+    ) is None
+
+
+def test_pre_charge_check_fails_open_when_unreachable(stripe_client, monkeypatch):
+    """If the speculative check itself cannot run, fall through to the trigger
+    rather than refusing every booking — the trigger is still the backstop."""
+    def _boom(name, params):
+        raise RuntimeError("supabase unreachable")
+
+    monkeypatch.setattr(stripe_client.supabase, "rpc", _boom, raising=False)
+
+    assert stripe_client._reservation_validation_error(
+        "listing-1", "2026-08-01T10:00:00+00:00", "2026-08-01T12:00:00+00:00"
+    ) is None
+
+
+# ── the gate is WIRED, not merely present ──────────────────────────────────────
+# The bug was never a missing rule; it was a rule that ran after the money moved.
+# A test that only exercises the helper would pass even if create_booking_payment
+# never called it, so this pins the call site itself.
+
+class _FluentTable:
+    """supabase.table(...).select(...).eq(...).single().execute() -> .data"""
+
+    def __init__(self, data):
+        self._data = data
+
+    def select(self, *_a, **_k):
+        return self
+
+    def eq(self, *_a, **_k):
+        return self
+
+    def single(self):
+        return self
+
+    def execute(self):
+        return types.SimpleNamespace(data=self._data)
+
+
+def test_create_booking_payment_refuses_before_touching_stripe(stripe_client, monkeypatch):
+    from flask import Flask
+
+    listing = {
+        "owner_id": "owner-1", "hourly_rate": None, "daily_rate": None,
+        "weekly_rate": None, "monthly_rate": None, "price_per_hour": None,
+    }
+    monkeypatch.setattr(stripe_client.supabase, "table",
+                        lambda _name: _FluentTable(listing), raising=False)
+
+    # The DB says no.
+    monkeypatch.setattr(stripe_client, "_reservation_validation_error",
+                        lambda *_a: "No rates available for this listing")
+
+    # Anything that would move money or take a slot must never be reached.
+    def _forbidden(*_a, **_k):
+        raise AssertionError("must not be called before validation passes")
+
+    created = []
+    monkeypatch.setattr(stripe_client.stripe, "PaymentIntent",
+                        types.SimpleNamespace(create=_forbidden))
+    monkeypatch.setattr(stripe_client.stripe, "Customer",
+                        types.SimpleNamespace(create=_forbidden))
+    monkeypatch.setattr(stripe_client.supabase, "rpc", _forbidden, raising=False)
+
+    app = Flask(__name__)
+    with app.app_context():
+        response, status = stripe_client.create_booking_payment(
+            "listing-1", "renter-1", "vehicle-1",
+            "2026-08-01T10:00:00+00:00", "2026-08-01T12:00:00+00:00",
+        )
+
+    assert status == 400
+    body = response.get_json()
+    assert body["code"] == "invalid_booking"
+    assert body["error"] == "No rates available for this listing"
+    assert created == []
+
+
+def _finalize_with(stripe_client, monkeypatch, outcome_error, refund_result="refunded"):
+    """Drive finalize_booking against a succeeded PI whose reservation fails."""
+    from flask import Flask
+
+    monkeypatch.setattr(
+        stripe_client.stripe, "PaymentIntent",
+        types.SimpleNamespace(retrieve=lambda *_a, **_k: {"id": "pi_331", "status": "succeeded"}),
+    )
+    monkeypatch.setattr(stripe_client, "_finalize_reservation_from_pi",
+                        lambda _pi: {"error": outcome_error})
+    refunds = []
+
+    def _fake_refund(pi_id, reason):
+        refunds.append((pi_id, reason))
+        return refund_result
+
+    monkeypatch.setattr(stripe_client, "_refund_stranded_payment", _fake_refund)
+
+    app = Flask(__name__)
+    with app.app_context():
+        response, status = stripe_client.finalize_booking("pi_331")
+        return response.get_json(), status, refunds
+
+
+def test_finalize_refunds_and_says_so_on_terminal_failure(stripe_client, monkeypatch):
+    """The wiring, not just the helper: a terminal failure must actually trigger
+    the refund and tell the renter they were not charged — the old behaviour was
+    a 409 plus 'contact support'."""
+    body, status, refunds = _finalize_with(
+        stripe_client, monkeypatch,
+        "db_P0001: Daily bookings not supported for this listing",
+    )
+
+    assert status == 409
+    assert refunds == [("pi_331", "db_P0001: Daily bookings not supported for this listing")]
+    assert body["refunded"] is True
+    assert "not been charged" in body["message"]
+
+
+def test_finalize_does_not_refund_a_retryable_failure(stripe_client, monkeypatch):
+    """A dropped connection may succeed on the webhook's retry; refunding it
+    would cancel a booking that is about to work."""
+    body, status, refunds = _finalize_with(
+        stripe_client, monkeypatch, "db_error: connection reset by peer",
+    )
+
+    assert status == 409
+    assert refunds == [], "must not refund a retryable failure"
+    assert body["refunded"] is False
+    assert body["refund_status"] == "retryable"
+
+
+def test_finalize_is_honest_when_the_refund_itself_fails(stripe_client, monkeypatch):
+    """If the make-good fails, the renter must be told to contact support — that
+    message is correct HERE and was wrong before, when it was shown even though
+    no refund had been attempted at all."""
+    body, status, _ = _finalize_with(
+        stripe_client, monkeypatch, "slot_unavailable", refund_result="refund_failed",
+    )
+
+    assert status == 409
+    assert body["refunded"] is False
+    assert "Contact support" in body["message"]

--- a/tests/backend/test_stranded_payment_refund.py
+++ b/tests/backend/test_stranded_payment_refund.py
@@ -314,4 +314,62 @@ def test_finalize_is_honest_when_the_refund_itself_fails(stripe_client, monkeypa
 
     assert status == 409
     assert body["refunded"] is False
-    assert "Contact support" in body["message"]
+    assert "contact support" in body["message"].lower()
+
+
+# ── no SQLSTATE may ever reach a renter's screen ───────────────────────────────
+# A customer read "db_P0001: Daily bookings not supported for this listing" in a
+# dialog, because finalize's catch-all formats DB failures as
+# 'db_<SQLSTATE>: <SQLERRM>' and the UI displayed that string directly.
+
+@pytest.mark.parametrize("error", [
+    "db_P0001: No rates available for this listing",
+    "db_P0001: Listing not found",
+    "db_23505: duplicate key value violates unique constraint \"reservations_pkey\"",
+    "db_23P01: conflicting key value violates exclusion constraint \"no_overlap\"",
+    "slot_unavailable",
+    "missing_metadata: vehicle_id",
+    "db_error: connection reset by peer",
+    "rpc_empty_response",
+])
+def test_no_response_message_leaks_a_sqlstate_or_internals(stripe_client, monkeypatch, error):
+    body, status, _ = _finalize_with(stripe_client, monkeypatch, error)
+
+    assert status == 409
+    message = body["message"]
+    assert "db_" not in message, f"raw error string leaked into the message: {message}"
+    assert "SQLSTATE" not in message
+    assert "constraint" not in message.lower(), "Postgres internals must not be shown"
+    assert message[0].isupper() and message.rstrip().endswith((".", "!")), \
+        f"not a presentable sentence: {message!r}"
+    # The raw string is still available for logs and support, just not for display.
+    assert body["detail"] == error
+
+
+def test_our_own_raise_text_is_surfaced_because_it_is_human(stripe_client, monkeypatch):
+    """P0001 means 'a trigger of ours raised', and that text is written by us for
+    people — so it is worth showing, unlike constraint internals."""
+    body, _, _ = _finalize_with(
+        stripe_client, monkeypatch, "db_P0001: No rates available for this listing")
+
+    assert body["message"].startswith("No rates available for this listing.")
+
+
+def test_conflict_becomes_plain_english_not_constraint_names(stripe_client, monkeypatch):
+    body, _, _ = _finalize_with(
+        stripe_client, monkeypatch,
+        'db_23P01: conflicting key value violates exclusion constraint "no_overlap"')
+
+    assert body["message"].startswith("That spot was just booked by someone else.")
+
+
+def test_retryable_message_does_not_alarm_or_invite_a_second_payment(stripe_client, monkeypatch):
+    """The payment stands and the webhook will finish the booking, so the renter
+    must not be told they were refunded, nor nudged into paying twice."""
+    body, _, refunds = _finalize_with(
+        stripe_client, monkeypatch, "db_error: connection reset by peer")
+
+    assert refunds == []
+    message = body["message"].lower()
+    assert "refund" not in message
+    assert "don't pay again" in message or "do not pay again" in message

--- a/tests/backend/test_ticket_41_pricing.py
+++ b/tests/backend/test_ticket_41_pricing.py
@@ -8,12 +8,13 @@ def iso(dt):
     return dt.astimezone(timezone.utc).isoformat()
 
 
-def make_listing(hourly=10, daily=None, weekly=None, monthly=None):
+def make_listing(hourly=10, daily=None, weekly=None, monthly=None, price_per_hour=None):
     return {
         'hourly_rate': hourly,
         'daily_rate': daily,
         'weekly_rate': weekly,
         'monthly_rate': monthly,
+        'price_per_hour': price_per_hour,
     }
 
 
@@ -34,10 +35,74 @@ def test_boundary_8_9_vs_9_0():
     assert Decimal('85.00') == res2['subtotal']
 
 
-def test_missing_required_tier_rejected():
-    now = datetime.now(timezone.utc)
-    start = now
-    end = start + timedelta(hours=10)  # daily tier applies
+def test_long_booking_on_hourly_only_listing_is_priced_hourly():
+    """A listing with no daily_rate is still bookable for more than a day, and
+    is charged hourly for the whole span.
+
+    This replaces an older test that asserted the opposite (PricingError). That
+    assertion encoded the original strict rule; the engine was later changed to
+    fall back across tiers, matching the product ruling — "users should be able
+    to still reserve for more than a day, they would just be charged with the
+    hourly rate" (2026-07-26). The old test sat red and unnoticed (no CI, see
+    issue #45), which is how the engine and the DB trigger drifted apart:
+    validate_reservation_rate() still demanded a daily_rate and rejected these
+    bookings AFTER Stripe had captured. See migration
+    20260730005125_align_reservation_rate_validation.sql.
+    """
+    start = datetime(2026, 7, 23, 23, 30, tzinfo=timezone.utc)
+    end = start + timedelta(hours=10)
     listing = make_listing(hourly=10, daily=None)
+
+    res = calculate_final_price(listing, iso(start), iso(end))
+
+    assert res['tier'] == 'hourly'
+    assert Decimal('100.00') == res['subtotal']  # 10h * $10, no daily cap to apply
+
+
+def test_the_331_regression_prices_and_the_db_accepts_it():
+    """The exact booking from the stranded-payment report: 96 hours on a $3/hr
+    listing with no daily rate. Pins the amount that was actually captured, so
+    if the engine's fallback is ever removed again the divergence resurfaces
+    here instead of on a renter's card.
+    """
+    start = datetime(2026, 7, 23, 23, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 27, 23, 30, tzinfo=timezone.utc)  # 96h
+    listing = make_listing(hourly=Decimal('3.00'), daily=None)
+
+    res = calculate_final_price(listing, iso(start), iso(end))
+
+    assert res['tier'] == 'hourly'
+    assert Decimal('288.00') == res['subtotal']       # 96h * $3
+    assert Decimal('43.20') == res['platform_fee']    # 15% hourly/daily fee
+    assert Decimal('331.20') == res['total']
+
+
+def test_legacy_price_per_hour_listing_is_priced():
+    """hourly_rate is nullable but price_per_hour is NOT NULL on listings, so a
+    listing carrying only the legacy column is a real shape. The engine falls
+    back to it; the trigger used to read hourly_rate alone and rejected these
+    bookings after capture — the second, quieter instance of the same bug.
+    """
+    start = datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+    end = start + timedelta(hours=2)
+    listing = make_listing(hourly=None, price_per_hour=Decimal('3.00'))
+
+    res = calculate_final_price(listing, iso(start), iso(end))
+
+    assert res['tier'] == 'hourly'
+    assert Decimal('6.00') == res['subtotal']
+    assert Decimal('6.90') == res['total']
+
+
+def test_listing_with_no_usable_rate_is_still_refused():
+    """The one rejection the engine and the trigger agree on, and the reason the
+    trigger was narrowed rather than dropped: no rate anywhere means there is no
+    honest price to charge.
+    """
+    start = datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+    end = start + timedelta(hours=2)
+    listing = make_listing(hourly=None, daily=None, weekly=None, monthly=None,
+                           price_per_hour=None)
+
     with pytest.raises(PricingError):
         calculate_final_price(listing, iso(start), iso(end))

--- a/tests/backend/test_ticket_6_reservation_sync.py
+++ b/tests/backend/test_ticket_6_reservation_sync.py
@@ -1,125 +1,200 @@
 #!/usr/bin/env python3
 """
-Smoke tests for Ticket #6: Reservation Sync & Conversation Creation
-Tests the new endpoints and RPC functions locally.
+Integration tests for Ticket #6: Reservation Sync & Conversation Creation.
+Tests the new endpoints and RPC functions against a live Flask backend.
+
+These hit a real running server (BASE_URL below) rather than a fake/mock, so
+a test here can only mean one of three things: the backend is unreachable
+(SKIP, with a reason), the backend is reachable and behaves correctly (PASS),
+or the backend is reachable and behaves incorrectly (FAIL). Earlier versions
+of this file used `return True/False` instead of `assert`, which pytest
+treats as a pass either way (only a PytestReturnNotNoneWarning is emitted) —
+so all four tests here were vacuous and could never fail.
 """
 
-import requests
-import json
-from datetime import datetime, timedelta
 import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import requests
 
 BASE_URL = "http://localhost:5000/api"
+REQUEST_TIMEOUT = 5
 
-def log_test(test_name, status, details=""):
-    """Helper to log test results."""
-    symbol = "✓" if status else "✗"
-    print(f"\n[{symbol}] {test_name}")
-    if details:
-        print(f"    {details}")
 
-def test_listings_without_time_range():
-    """Test backward-compatible listings endpoint (no time range)."""
+def _backend_reachable():
+    """True only if something that looks like the SpotOn Flask API — not just
+    "something" — is listening at BASE_URL.
+
+    A plain TCP/HTTP success isn't enough: on macOS, ControlCenter's AirPlay
+    Receiver listens on port 5000 by default and answers every request with
+    an empty 403 (`Server: AirTunes/...`, zero-length body). `requests.get`
+    treats that as a normal response, not a connection error — treating it as
+    "reachable" would make every assertion below FAIL (not SKIP) on a stock
+    Mac with no SpotOn backend running at all, which defeats the point of
+    skipping. `GET /api/listings` (backend/routes/listings.py) always
+    `jsonify`s its response, success or error, so requiring a parseable JSON
+    body is a reliable signal this is actually our Flask app.
+    """
     try:
-        resp = requests.get(f"{BASE_URL}/listings", timeout=5)
-        log_test("GET /api/listings (no time range)", resp.status_code == 200, f"Status: {resp.status_code}")
-        if resp.status_code == 200:
-            print(f"    Response: {len(resp.json())} listings found")
-        return resp.status_code == 200
-    except Exception as e:
-        log_test("GET /api/listings (no time range)", False, f"Error: {str(e)}")
+        resp = requests.get(f"{BASE_URL}/listings", timeout=REQUEST_TIMEOUT)
+    except requests.exceptions.RequestException:
         return False
-
-def test_listings_with_time_range():
-    """Test listings endpoint with time-range availability filter."""
     try:
-        # Request listings for a specific 2-hour window
-        now = datetime.utcnow()
-        start_time = (now + timedelta(days=1)).isoformat() + "Z"
-        end_time = (now + timedelta(days=1, hours=2)).isoformat() + "Z"
-        
-        params = {"start_time": start_time, "end_time": end_time}
-        resp = requests.get(f"{BASE_URL}/listings", params=params, timeout=5)
-        
-        log_test("GET /api/listings (with time range)", resp.status_code == 200, 
-                f"Status: {resp.status_code}, Query: start_time={start_time}, end_time={end_time}")
-        if resp.status_code == 200:
-            print(f"    Response: {len(resp.json())} available listings for the requested time range")
-        return resp.status_code == 200
-    except Exception as e:
-        log_test("GET /api/listings (with time range)", False, f"Error: {str(e)}")
+        resp.json()
+    except ValueError:
         return False
+    return True
 
-def test_create_reservation_basic():
-    """Test basic reservation creation (without actual DB state)."""
+
+@pytest.fixture(scope="module")
+def backend():
+    """Skip this module's tests if no live backend is running at BASE_URL.
+
+    An unreachable (or not-actually-our-API) backend means "no server to
+    test against", not "the feature is broken" — so it must SKIP, not
+    silently pass and not hard-fail the suite for someone without a local
+    Flask server. It must never be turned into a `pass`/`except: return
+    False` that reports green regardless.
+    """
+    if not _backend_reachable():
+        pytest.skip(
+            f"No SpotOn backend reachable at {BASE_URL} — start the Flask app "
+            f"on localhost:5000 to run these integration tests. (If something "
+            f"else answers on port 5000 — e.g. macOS AirPlay Receiver — this "
+            f"will also skip, since that isn't the backend under test.)"
+        )
+    return BASE_URL
+
+
+def test_listings_without_time_range(backend):
+    """Backward-compatible listings endpoint (no time range) must return the
+    full listing set as a 200 with a JSON list body."""
+    resp = requests.get(f"{backend}/listings", timeout=REQUEST_TIMEOUT)
+
+    assert resp.status_code == 200, (
+        f"GET /api/listings expected 200, got {resp.status_code}: {resp.text}"
+    )
+    listings = resp.json()
+    assert isinstance(listings, list), (
+        f"expected /api/listings to return a JSON list, got {type(listings).__name__}"
+    )
+
+
+def test_listings_with_time_range(backend):
+    """Listings endpoint with a start_time/end_time filter must still return
+    200 with a JSON list (of listings available for that window)."""
+    now = datetime.utcnow()
+    start_time = (now + timedelta(days=1)).isoformat() + "Z"
+    end_time = (now + timedelta(days=1, hours=2)).isoformat() + "Z"
+
+    params = {"start_time": start_time, "end_time": end_time}
+    resp = requests.get(f"{backend}/listings", params=params, timeout=REQUEST_TIMEOUT)
+
+    assert resp.status_code == 200, (
+        f"GET /api/listings?start_time={start_time}&end_time={end_time} "
+        f"expected 200, got {resp.status_code}: {resp.text}"
+    )
+    listings = resp.json()
+    assert isinstance(listings, list), (
+        f"expected /api/listings (time-range filtered) to return a JSON list, "
+        f"got {type(listings).__name__}"
+    )
+
+
+def test_create_reservation_basic(backend):
+    """Reservation creation endpoint must be reachable and return one of the
+    documented outcomes for a payload with a random (non-existent) listing_id
+    and renter_id: 201 if the DB somehow accepts it, 404/409 if it correctly
+    rejects the unknown listing or an overlap, or 500 on a surfaced DB error.
+    Anything else (e.g. a 4xx we don't expect, or a non-JSON body) is a real
+    failure of the endpoint's contract.
+    """
+    payload = {
+        "listing_id": str(uuid.uuid4()),
+        "renter_id": str(uuid.uuid4()),
+        "start_time": (datetime.utcnow() + timedelta(days=2)).isoformat() + "Z",
+        "end_time": (datetime.utcnow() + timedelta(days=2, hours=2)).isoformat() + "Z",
+        "total_price": 25.00,
+    }
+
+    resp = requests.post(f"{backend}/reservations", json=payload, timeout=REQUEST_TIMEOUT)
+
+    assert resp.status_code in (201, 404, 409, 500), (
+        f"POST /api/reservations with a random listing_id/renter_id returned "
+        f"an unexpected status {resp.status_code} (expected 201/404/409/500): {resp.text}"
+    )
+    # The endpoint must always answer with a JSON body, even on error, so
+    # callers (and this test) can inspect why.
     try:
-        # This is a smoke test showing the endpoint responds correctly
-        # A full test would require valid listing_id, renter_id, owner_id from the DB
-        payload = {
-            "listing_id": str(uuid.uuid4()),
-            "renter_id": str(uuid.uuid4()),
-            "start_time": (datetime.utcnow() + timedelta(days=2)).isoformat() + "Z",
-            "end_time": (datetime.utcnow() + timedelta(days=2, hours=2)).isoformat() + "Z",
-            "total_price": 25.00
+        resp.json()
+    except ValueError:
+        pytest.fail(
+            f"POST /api/reservations returned status {resp.status_code} with a "
+            f"non-JSON body: {resp.text!r}"
+        )
+
+
+def test_overlap_detection(backend):
+    """The Postgres exclusion constraint (reservations_no_overlap, requires
+    btree_gist) must reject a second reservation that overlaps a first one on
+    the same listing.
+
+    This replaces the old version of the test, which never actually created a
+    reservation and instead just printed a claim that the constraint exists.
+    """
+    listings_resp = requests.get(f"{backend}/listings", timeout=REQUEST_TIMEOUT)
+    assert listings_resp.status_code == 200, (
+        f"could not fetch listings to set up the overlap test: "
+        f"{listings_resp.status_code}: {listings_resp.text}"
+    )
+    listings = listings_resp.json()
+    if not listings:
+        pytest.skip("backend has no listings to exercise overlap detection against")
+
+    listing_id = listings[0]["id"]
+    renter_id = str(uuid.uuid4())
+
+    # Far-future window so this doesn't collide with unrelated real bookings.
+    start = datetime.utcnow() + timedelta(days=365)
+    end = start + timedelta(hours=2)
+    # Second window starts inside the first and extends past it: a genuine overlap.
+    overlap_start = start + timedelta(minutes=30)
+    overlap_end = overlap_start + timedelta(hours=2)
+
+    def _reservation_payload(s, e):
+        return {
+            "listing_id": listing_id,
+            "renter_id": renter_id,
+            "start_time": s.isoformat() + "Z",
+            "end_time": e.isoformat() + "Z",
+            "total_price": 25.00,
         }
-        
-        resp = requests.post(f"{BASE_URL}/reservations", json=payload, timeout=5)
-        
-        # Expect 404 (listing not found) or 409 (overlap) or 201 (success) depending on DB state
-        # For smoke test, we just verify the endpoint is reachable and returns proper HTTP status
-        is_ok = resp.status_code in [201, 404, 409, 500]
-        log_test("POST /api/reservations (smoke test)", is_ok, 
-                f"Status: {resp.status_code}, Response: {resp.json()}")
-        return is_ok
-    except Exception as e:
-        log_test("POST /api/reservations (smoke test)", False, f"Error: {str(e)}")
-        return False
 
-def test_overlap_detection():
-    """Test that the exclusion constraint prevents overlapping bookings."""
-    print("\n[INFO] Overlap detection requires live DB state. This would be tested in integration tests.")
-    print("       The Postgres exclusion constraint is enabled and will reject overlaps automatically.")
-    log_test("Exclusion Constraint Verification", True, 
-            "btree_gist extension enabled, reservations_no_overlap constraint created")
+    first = requests.post(
+        f"{backend}/reservations",
+        json=_reservation_payload(start, end),
+        timeout=REQUEST_TIMEOUT,
+    )
+    if first.status_code != 201:
+        # Can't establish the baseline booking (e.g. renter_id/listing FK
+        # constraints need real seed data we don't have here) — skip rather
+        # than fail, since we haven't yet exercised the invariant we're
+        # actually testing.
+        pytest.skip(
+            f"could not create the baseline reservation needed to test overlap "
+            f"detection (status {first.status_code}: {first.text})"
+        )
 
-def main():
-    print("=" * 70)
-    print("SPOTON TICKET #6 SMOKE TESTS: Reservation Sync & Conversation Creation")
-    print("=" * 70)
-    
-    tests_passed = 0
-    tests_total = 0
-    
-    # Test 1: Backward-compatible listings endpoint
-    tests_total += 1
-    if test_listings_without_time_range():
-        tests_passed += 1
-    
-    # Test 2: Time-range aware listings endpoint
-    tests_total += 1
-    if test_listings_with_time_range():
-        tests_passed += 1
-    
-    # Test 3: Reservation creation endpoint
-    tests_total += 1
-    if test_create_reservation_basic():
-        tests_passed += 1
-    
-    # Test 4: Overlap detection verification
-    tests_total += 1
-    test_overlap_detection()
-    tests_passed += 1
-    
-    print("\n" + "=" * 70)
-    print(f"RESULTS: {tests_passed}/{tests_total} smoke tests passed")
-    print("=" * 70)
-    
-    if tests_passed == tests_total:
-        print("\n✓ All smoke tests passed! Ready for integration testing.")
-        return 0
-    else:
-        print(f"\n✗ {tests_total - tests_passed} smoke test(s) failed. Check server logs.")
-        return 1
+    second = requests.post(
+        f"{backend}/reservations",
+        json=_reservation_payload(overlap_start, overlap_end),
+        timeout=REQUEST_TIMEOUT,
+    )
 
-if __name__ == "__main__":
-    exit(main())
+    assert second.status_code in (409, 400), (
+        f"a reservation overlapping an existing one on the same listing "
+        f"({listing_id}) should have been rejected (409/400) by the "
+        f"reservations_no_overlap exclusion constraint, but got "
+        f"{second.status_code}: {second.text}"
+    )


### PR DESCRIPTION
> **Stacked on #62.** Base is `chore/declare-python-version`, so this diff shows only its own work. GitHub retargets it to `holdPayouts` automatically once #62 merges. Review commit-by-commit — each commit is self-contained.

Closes #45. Relates to #41 (temporal booking logic) and #58 (test coverage).

## The bug: `db_P0001` — $331.20 charged, no reservation

Two implementations of "which durations may be booked" disagreed, and money moves before the stricter one runs:

| | rule for a 4-day booking on a `$3/hr`, `daily_rate = NULL` listing |
|---|---|
| `pricing.calculate_final_price` | no daily rate? fall back to **hourly** → 96 h × $3 = **$288** |
| `validate_reservation_rate` trigger | duration ≥ 9 h and no `daily_rate`? → **`RAISE`** |

$288 + 15% fee = **$331.20** — exactly the amount captured. `create_booking_payment` prices with Python and charges; the trigger only fires later at `finalize_paid_reservation`'s INSERT, whose `WHEN OTHERS` handler formats `'db_' || SQLSTATE`. Hence the string on screen.

**A second instance nobody knew about:** a *short* booking on a legacy listing where only `price_per_hour` is set and `hourly_rate` is NULL. Python falls back to `price_per_hour`; the trigger read `hourly_rate` alone. `price_per_hour` is `NOT NULL` while `hourly_rate` is nullable, so that shape is real. Both reproduced in SQL against the real schema.

**Why it hid:** `test_missing_required_tier_rejected` asserted the *old* strict rule and had been **red for weeks**. No CI, so nobody saw it. The engine was relaxed; the trigger and the test were never updated.

## The fix — structural, not per-instance

@00adrn heads up: this differs from "just remove the check". Deleting the trigger outright would also drop its one legitimate arm (a listing with **no** usable rate at all). Instead:

- **`reservation_validation_error(listing, start, end)` is now the single definition** of "may this reservation exist". The trigger raises whatever it returns, and `create_booking_payment` calls the *same function* over RPC **before** creating the PaymentIntent. A rule can no longer reject a booking only after the card is charged.
- It rejects exactly what the pricing engine refuses to price — reading `hourly_rate` then legacy `price_per_hour`, per @ehanrsha's ruling that multi-day bookings on hourly-only listings are allowed and charged hourly.
- **Terminal failures now auto-refund**, idempotently, and tell the renter they weren't charged. This is the refund-on-conflict the code marked *"intentionally deferred … needs manual review"*.
- **Terminal vs retryable is distinguished:** `P0001` and class-23 SQLSTATEs are terminal; a dropped connection is not, because refunding it would cancel a booking the webhook retry is about to complete.
- **No renter sees a SQLSTATE again.** Every 409 carries a displayable `message`; the raw string moves to `detail` for logs. `P0001` text is ours and human so it's surfaced; class-23 text names constraints and becomes "That spot was just booked by someone else."

## Tests: 47 passed, 4 skipped (was 9 with one red and four vacuous)

- **Four tests could not fail.** Everything in `test_ticket_6_reservation_sync.py` used `return` instead of `assert`, and pytest passes a test that returns a value. Three were returning `False` from an `except` branch while reporting green. They now assert, and skip *with a reason* when no backend is reachable. The probe requires parseable JSON, because macOS AirPlay Receiver squats on port 5000 and answers with an empty 403 — a plain connection check would call that "reachable" and turn every assertion into a false failure.
- **Notification triggers covered** (purchase / start / end, both parties, once each) and the `UNIQUE(reservation_id, event_key)` dedupe verified against the webhook-plus-client double finalize.
- Everything above was mutation-verified: removing the pre-charge gate, reverting the refund, dropping the dedupe, and returning the raw error as the message each fail their intended tests.

## CI (closes #45)

Three independent jobs, so one red never hides another:

- **backend** — interpreter from `.python-version`, explicit `import app` step (an import failure should read as itself, not as a wall of collection errors), then `pytest -rs` so skip reasons are visible.
- **frontend** — `npm ci`, lint, jest. Blocking on lint **errors** only; the 46 pre-existing warnings stay visible but non-fatal.
- **migrations** — filenames timestamp-ordered and unique (`supabase db push` refuses a migration dated before one already applied, so two branches can create a pair that only breaks once *both* land), plus balanced `BEGIN`/`COMMIT` and dollar quotes.

**Two real frontend bugs were fixed to make lint green on arrival**, rather than shipping CI red:

- `EditableProfileCard` called `useRef`/`useState`/`useEffect` **after** an early `if (!setName || !rating) return null`. React matches hooks by call order, so a render that bails calls zero and the next calls three → *"rendered more hooks than during the previous render"* and the card unmounts. Reachable today: `!rating` is true for a rating of **0**, i.e. every brand-new user, so it bailed and then crashed the moment a real rating loaded. Hooks moved above the return; the condition is unchanged, so rendering behaviour is identical.
- an unescaped apostrophe in MenuBar copy.

## Known follow-ups, deliberately not in this PR

- **Applying migrations in CI.** The base migration is a `supabase db pull` dump that references platform schemas it never creates, so it won't replay on a bare Postgres image — I tried. The right tool is `supabase/setup-cli` + `supabase db start`; the recipe is in a comment, left for a verified run rather than a guess.
- **`supabase_client.py` builds its client at module import**, so nothing under `backend/` can be imported without credentials — that's why every test stubs it, and why CI's import step needs placeholder env vars. Making it lazy is the real fix, but it's a shared module and deserves its own review.