### PR TITLE
fix: enable row-level security on reservations (B2)

### DIFF
--- a/supabase/migrations/20260808120000_enable_rls_on_reservations.sql
+++ b/supabase/migrations/20260808120000_enable_rls_on_reservations.sql
@@ -1,0 +1,40 @@
+-- Switch on row-level security for public.reservations.
+--
+-- The three policies below already exist — they were created in
+-- 20260421001633_remote_schema.sql (lines 463-477) and have been inert ever
+-- since, because nothing ever ran ENABLE ROW LEVEL SECURITY on the table.
+-- Postgres keeps policies attached to a table whether or not row security is
+-- on; with it off they are simply never consulted. `\d public.reservations`
+-- says so in as many words: "Policies (row security disabled)".
+--
+-- reservations was the only application table left in that state. listings,
+-- profiles, conversations, messages, vehicles, reservation_holds and
+-- notification_events all had it enabled already.
+--
+-- What that meant in practice: the anon role — which is what the publishable
+-- key shipped inside the mobile app bundle authenticates as — could read every
+-- reservation in the table, including live Stripe payment-intent ids, rewrite
+-- any booking's price and status, and DELETE bookings outright, taking their
+-- conversation, every message in it and its notification_events rows along via
+-- ON DELETE CASCADE. No account was required.
+--
+-- The intended policies, for reference:
+--   reservations_parties_select  SELECT  renter, or owner of the listing
+--   reservations_renter_insert   INSERT  renter_id must equal auth.uid()
+--   reservations_update_status   UPDATE  renter, or owner of the listing
+-- All three are TO authenticated, so anon matches no policy at all and is
+-- denied every verb.
+--
+-- Deliberately NOT adding a DELETE policy: no client should delete a
+-- reservation directly, and no frontend code path does. Cancellation flows
+-- through the backend, which holds the service-role key and bypasses RLS.
+
+ALTER TABLE public.reservations ENABLE ROW LEVEL SECURITY;
+
+-- Fail loudly if this ever silently regresses.
+DO $$
+BEGIN
+  IF NOT (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.reservations'::regclass) THEN
+    RAISE EXCEPTION 'row-level security is still disabled on public.reservations';
+  END IF;
+END $$;


### PR DESCRIPTION
Closes blocker **B2** from the security review. One line of SQL, plus a guard that fails loudly if it ever regresses.

## What was wrong

`public.reservations` was the only application table with row-level security switched off. `listings`, `profiles`, `conversations`, `messages`, `vehicles`, `reservation_holds` and `notification_events` all had it on.

The three policies meant to protect it were written back in April (`20260421001633_remote_schema.sql:463-477`) and have been **inert ever since** — Postgres keeps policies attached to a table whether or not row security is enabled, and nothing ever enabled it. `\d public.reservations` says so in as many words:

```
Policies (row security disabled):
    POLICY "reservations_parties_select" FOR SELECT
```

So the `anon` role — which is what the publishable key **shipped inside the app bundle** authenticates as — could do all of this with no account:

| verb | before |
|---|---|
| `SELECT` | any user's booking, including its live Stripe payment-intent id |
| `UPDATE` | rewrite any booking's `total_price` and `status` |
| `DELETE` | remove a booking, cascading away its conversation, every message in it, and its `notification_events` rows |

## Verification

Reproduced against the real migrations in a throwaway Postgres (not the shared stack), loading the actual dump plus every migration in order.

**Before — acting as `anon`, no JWT:**
```
SELECT  -> 22222222-…  20.00  paid  pi_SECRET_live_abc123
UPDATE  -> total_price 0.01, status confirmed
DELETE  -> reservations_after 0, messages_after_cascade 0
```

**After:**
```
SELECT  -> 0 rows      UPDATE -> UPDATE 0
DELETE  -> DELETE 0    INSERT -> denied
```

**And the app still works.** I checked every one of the 10 places the frontend touches `reservations` directly, and exercised each shape:

| caller | query | result |
|---|---|---|
| renter — `getActiveReservations`, `getUpcoming`, `getInProgress`, `getReservations` | `.eq('renter_id', me)` | sees own bookings |
| owner — `getOwnerActiveBookings`, `getPendingPayout`, YourSpots earnings | `.in('listing_id', my listings)` | sees bookings on own spots, payout total intact |
| renter — `reserveSpot` | `.insert({renter_id: me})` | still allowed |
| stranger (logged in, unrelated) | any | sees nothing; cannot book in another user's name |
| backend (`service_role`) | any | still bypasses RLS entirely |

The policy predicate was also evaluated in isolation, because a cross-user insert is independently blocked by the vehicle-ownership trigger and I didn't want that masking the result: as an unrelated user, `auth.uid() = renter_id` evaluates false, while their own legitimate booking succeeds.

No frontend path deletes a reservation, so **no DELETE policy is added on purpose** — cancellation goes through the backend, which holds the service-role key.

## ⚠️ Merging this does not change the live database

There is no `supabase db push`, `supabase link`, or migration step anywhere in `.github/`, `docs/`, or `package.json`. Files in `supabase/migrations/` describe the database; they don't drive it.

**Someone has to run this against the hosted project**, then confirm:

```sql
ALTER TABLE public.reservations ENABLE ROW LEVEL SECURITY;
SELECT relrowsecurity FROM pg_class WHERE oid = 'public.reservations'::regclass;  -- expect t
```

## Notes

- No CI on this PR — the workflow isn't on `main` yet (#62 → #63 brings it). The container transcript above is the verification.
- Related, not fixed here: `reservations.status` has no `NOT NULL`, and every double-booking guard compares `status <> 'cancelled'`, which is NULL-unsafe — a NULL status drops a row out of all of them at once. That wants a backfill check, so it belongs in its own PR.