### PR TITLE
fix: pick the rate tier by duration, not by which rates exist (B4)

### DIFF
--- a/backend/utils/pricing.py
+++ b/backend/utils/pricing.py
@@ -91,6 +91,11 @@ def _compute_daily_only(daily_rate: Decimal, dur_days: Decimal):
     return subtotal, None, 'daily', daily_rate, units
 
 
+def _fee_rate(tier: str) -> Decimal:
+    """Platform fee by tier: short stays 15%, long stays 7%."""
+    return Decimal('0.15') if tier in ('hourly', 'daily') else Decimal('0.07')
+
+
 def calculate_final_price(listing: Dict[str, Any], start_ts, end_ts) -> Dict[str, Any]:
     start = _parse_iso8601(start_ts)
     end = _parse_iso8601(end_ts)
@@ -110,46 +115,52 @@ def calculate_final_price(listing: Dict[str, Any], start_ts, end_ts) -> Dict[str
     weekly_rate = _to_decimal(listing.get('weekly_rate'))
     monthly_rate = _to_decimal(listing.get('monthly_rate'))
 
-    line_items = None
-    subtotal = None
+    # ── Tier selection ─────────────────────────────────────────────────────────
+    # A tier is eligible when the STAY IS ACTUALLY THAT LONG. It used to be
+    # eligible when the RATE MERELY EXISTED, which is the entire bug: any listing
+    # with a weekly or monthly rate took the long-stay path, where `units` is
+    # floored at 1, so a short booking was billed a whole period. A $10/hr listing
+    # with a $500 monthly rate charged $535 for one hour; $3/hr with $50/week
+    # charged $53.50 for ten minutes. The hourly and daily branches below were
+    # unreachable for any such listing — which is why this never showed up as a
+    # wrong number in the common case, only as a wrong TIER.
+    #
+    # The duration thresholds and their precedence are unchanged from before, so
+    # a booking long enough to have qualified for a coarse tier still gets exactly
+    # the same price. This fix only stops SHORT bookings being captured.
+    eps = Decimal('0.000001')
 
-    # ── Weekly / monthly listings ──────────────────────────────────────────────
-    if weekly_rate is not None or monthly_rate is not None:
-        eps = Decimal('0.000001')
-        if monthly_rate is not None and (dur_weeks + eps >= Decimal(4) or weekly_rate is None):
-            tier = 'monthly'
-            units = dur_months if dur_months >= Decimal(1) else Decimal(1)
-            rate_used = monthly_rate
-        elif weekly_rate is not None:
-            tier = 'weekly'
-            units = dur_weeks if dur_weeks >= Decimal(1) else Decimal(1)
-            rate_used = weekly_rate
-        elif daily_rate is not None:
-            tier = 'daily'
-            units = dur_days if dur_days >= Decimal(1) else Decimal(1)
-            rate_used = daily_rate
-        elif hourly_rate is not None:
-            subtotal, line_items, tier, rate_used, units = _compute_hourly_with_day_cap(hourly_rate, daily_rate, dur_hours)
-        else:
-            raise PricingError('No rates available for this listing')
+    coarse = None
+    if monthly_rate is not None and dur_weeks + eps >= Decimal(4):
+        m_units = dur_months if dur_months >= Decimal(1) else Decimal(1)
+        coarse = (monthly_rate * m_units, None, 'monthly', monthly_rate, m_units)
+    elif weekly_rate is not None and dur_days + eps >= Decimal(7):
+        w_units = dur_weeks if dur_weeks >= Decimal(1) else Decimal(1)
+        coarse = (weekly_rate * w_units, None, 'weekly', weekly_rate, w_units)
 
-        if subtotal is None:
-            subtotal = rate_used * units
-
-    # ── Hourly listings: use hourly rate as base, cap per day when daily_rate set ─
+    if coarse is not None:
+        subtotal, line_items, tier, rate_used, units = coarse
+    elif hourly_rate is not None:
+        # Folds in the daily rate, capping each full day at daily_rate.
+        subtotal, line_items, tier, rate_used, units = _compute_hourly_with_day_cap(
+            hourly_rate, daily_rate, dur_hours)
+    elif daily_rate is not None:
+        subtotal, line_items, tier, rate_used, units = _compute_daily_only(daily_rate, dur_days)
+    elif weekly_rate is not None:
+        # Too short to qualify, but a week is the finest rate published for this
+        # listing, so it is what the booking costs.
+        w_units = dur_weeks if dur_weeks >= Decimal(1) else Decimal(1)
+        subtotal, line_items, tier, rate_used, units = (
+            weekly_rate * w_units, None, 'weekly', weekly_rate, w_units)
+    elif monthly_rate is not None:
+        m_units = dur_months if dur_months >= Decimal(1) else Decimal(1)
+        subtotal, line_items, tier, rate_used, units = (
+            monthly_rate * m_units, None, 'monthly', monthly_rate, m_units)
     else:
-        if hourly_rate is None and daily_rate is not None:
-            subtotal, line_items, tier, rate_used, units = _compute_daily_only(daily_rate, dur_days)
-        elif hourly_rate is None:
-            raise PricingError('No hourly rate available for this listing')
-        else:
-            subtotal, line_items, tier, rate_used, units = _compute_hourly_with_day_cap(hourly_rate, daily_rate, dur_hours)
+        raise PricingError('No rates available for this listing')
 
     # ── Fee ────────────────────────────────────────────────────────────────────
-    if tier in ('hourly', 'daily'):
-        fee_rate = Decimal('0.15')
-    else:
-        fee_rate = Decimal('0.07')
+    fee_rate = _fee_rate(tier)
 
     quant = Decimal('0.01')
     subtotal = subtotal.quantize(quant, rounding=ROUND_HALF_UP)

--- a/tests/backend/test_b4_rate_tier_selection.py
+++ b/tests/backend/test_b4_rate_tier_selection.py
@@ -1,0 +1,124 @@
+"""Rate tier must be chosen by how long the booking is, not by which rates exist.
+
+Deliberately a separate file from test_ticket_41_pricing.py: that file covers the
+hourly/daily cap boundary and is being rewritten on another branch. These cases are
+about the weekly/monthly selection, which nothing covered before.
+
+Mutation-checked by swapping in origin/main's pricing.py and re-running: exactly
+two fail, the two reported cases, which produced tier 'monthly' and 'weekly'
+where they should have been 'hourly'. The numbers in their "was billed" comments
+are what it actually charged.
+
+The other seven pass either way, on purpose. They are regression guards for
+behaviour the fix had to leave alone, and their passing against BOTH
+implementations is the evidence that this change is one-directional: it stops
+short bookings being captured by a coarse tier and changes nothing else.
+"""
+import pytest
+from backend.utils.pricing import calculate_final_price, PricingError
+from decimal import Decimal
+from datetime import datetime, timedelta, timezone
+
+
+def iso(dt):
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def make_listing(hourly=10, daily=None, weekly=None, monthly=None):
+    return {
+        'hourly_rate': hourly,
+        'daily_rate': daily,
+        'weekly_rate': weekly,
+        'monthly_rate': monthly,
+    }
+
+
+def price(listing, **delta):
+    start = datetime(2026, 8, 10, 9, 0, tzinfo=timezone.utc)
+    return calculate_final_price(listing, iso(start), iso(start + timedelta(**delta)))
+
+
+# ── the two reported cases ────────────────────────────────────────────────────
+
+def test_one_hour_on_a_listing_with_a_monthly_rate_is_billed_hourly():
+    """$10/hr + $500/month, booked for one hour: was billed $535.00."""
+    res = price(make_listing(hourly=10, monthly=500), hours=1)
+    assert res['tier'] == 'hourly'
+    assert res['subtotal'] == Decimal('10.00')
+    assert res['total'] == Decimal('11.50')     # 10 + 15%
+
+
+def test_ten_minutes_on_a_listing_with_a_weekly_rate_is_billed_hourly():
+    """$3/hr + $50/week, booked for ten minutes: was billed $53.50."""
+    res = price(make_listing(hourly=3, weekly=50), minutes=10)
+    assert res['tier'] == 'hourly'
+    assert res['subtotal'] == Decimal('0.50')   # 3 * (10/60)
+    assert res['total'] == Decimal('0.58')      # 0.50 + 15%, half-up
+
+
+# ── the coarse tiers must still win when they are genuinely cheaper ───────────
+
+def test_a_two_month_booking_still_uses_the_monthly_rate():
+    """The discount a monthly rate exists to give must survive the fix."""
+    listing = make_listing(hourly=10, monthly=500)
+    res = price(listing, days=56)               # 8 weeks == 2 months
+    assert res['tier'] == 'monthly'
+    assert res['subtotal'] == Decimal('1000.00')
+    # Hourly would have been 56*24*10 = $13,440 before fees.
+    assert res['total'] == Decimal('1070.00')   # 1000 + 7%
+
+
+def test_a_two_week_booking_uses_the_weekly_rate():
+    listing = make_listing(hourly=10, weekly=100)
+    res = price(listing, days=14)
+    assert res['tier'] == 'weekly'
+    assert res['subtotal'] == Decimal('200.00')
+
+
+def test_five_weeks_still_prices_monthly_even_though_weekly_would_be_cheaper():
+    """Deliberately pinning EXISTING behaviour, not endorsing it.
+
+    Five weeks with weekly $50 and monthly $500: the >= 4 week threshold selects
+    monthly at 1.25 units = $625, where five weekly units would be $250. That is
+    a pricing-policy question about what a host is owed when both rates apply --
+    separate from this bug, which is only that bookings SHORTER than a period
+    were billed a whole one. Changing it would move host payout $625 -> $250 on
+    bookings that were never mispriced, so it is Ehan's call, not a bug fix.
+
+    This test exists so that decision is made deliberately rather than by
+    accident: if someone switches to cheapest-tier-wins, this fails and says why.
+    """
+    res = price(make_listing(hourly=None, weekly=50, monthly=500), days=35)
+    assert res['tier'] == 'monthly'
+    assert res['subtotal'] == Decimal('625.00')
+
+
+# ── edges ─────────────────────────────────────────────────────────────────────
+
+def test_monthly_only_listing_still_prices_a_short_booking_at_the_monthly_rate():
+    """Not a bug: it is the only rate the owner published.
+
+    Whether a monthly-only spot should be bookable by the hour at all is a
+    listing-constraint question (availability windows), not a pricing one.
+    """
+    res = price(make_listing(hourly=None, monthly=500), hours=1)
+    assert res['tier'] == 'monthly'
+    assert res['subtotal'] == Decimal('500.00')
+
+
+def test_daily_only_listing_is_unaffected():
+    res = price(make_listing(hourly=None, daily=40), days=3)
+    assert res['tier'] == 'daily'
+    assert res['subtotal'] == Decimal('120.00')
+
+
+def test_listing_with_no_rates_at_all_is_refused():
+    with pytest.raises(PricingError):
+        price(make_listing(hourly=None, daily=None, weekly=None, monthly=None), hours=2)
+
+
+def test_host_payout_and_fee_still_reconcile():
+    """total == subtotal + platform_fee, and the host is paid the subtotal."""
+    res = price(make_listing(hourly=10, monthly=500), hours=1)
+    assert res['total'] == res['subtotal'] + res['platform_fee']
+    assert res['host_payout'] == res['subtotal']


### PR DESCRIPTION
Closes blocker **B4** from the security review.

## What was wrong

A listing with a **$10 hourly** rate and a **$500 monthly** rate charged **$535 for a one-hour booking**. With **$3 hourly** and **$50 weekly**, **ten minutes cost $53.50**.

A tier became eligible when its **rate existed**, not when the **stay was actually that long**. Any listing with a weekly or monthly rate took the long-stay path, where `units` is floored at 1 — so a short booking was billed a whole period:

```python
if weekly_rate is not None or monthly_rate is not None:      # <- rate exists, not duration
    if monthly_rate is not None and (dur_weeks + eps >= 4 or weekly_rate is None):
        units = dur_months if dur_months >= 1 else Decimal(1)   # <- one hour becomes one month
```

The `or weekly_rate is None` clause made the monthly branch unconditional whenever no weekly rate was set, and the hourly/daily branches underneath were **unreachable** for any such listing. That's why this never showed up as a wrong *number* in the common case — only as a wrong *tier*.

## The fix

Coarse tiers are gated on duration: monthly needs ≥ 4 weeks, weekly needs ≥ 7 days. A listing whose only published rate is coarse still uses it. **The thresholds and their precedence are unchanged**, so any booking long enough to have qualified before gets exactly the same price.

## Deliberately not changed — flagging for @Nitroid

**Which coarse tier wins when both apply.** Five weeks with weekly $50 and monthly $500 still selects monthly at **$625**, where five weekly units would be **$250**.

I had this arbitrating by cheapest and backed it out. It would move **host payout $625 → $250** on bookings that were never mispriced — a pricing-policy question about what a host is owed, separable from this bug, and not something that should ride along inside a blocker fix. A test pins the current behaviour and explains why, so changing it later is a deliberate act rather than an accident.

## Verification

9 new tests in a **new file** rather than `test_ticket_41_pricing.py`, which is being rewritten on `ci/automated-checks` — all five of that branch's pricing tests pass against this change, so the two compose.

**Mutation-checked** by swapping in `origin/main`'s `pricing.py` and re-running:

```
FAILED  test_one_hour_on_a_listing_with_a_monthly_rate_is_billed_hourly
        AssertionError: assert 'monthly' == 'hourly'
FAILED  test_ten_minutes_on_a_listing_with_a_weekly_rate_is_billed_hourly
        AssertionError: assert 'weekly' == 'hourly'
2 failed, 7 passed
```

Exactly the two reported cases fail. The other seven pass against **both** implementations on purpose — that's the evidence this change is one-directional: it stops short bookings being captured and changes nothing else.

Full suite: `14 passed, 1 failed`. The failure is `test_missing_required_tier_rejected`, which **already fails on `main`** and is rewritten by #63.

## Notes

- No CI on this PR — the workflow isn't on `main` yet (#62 → #63 brings it, *and* fixes that failing test).
- The error string for a listing with no usable rate changes from `'No hourly rate available for this listing'` to `'No rates available for this listing'`, matching what the DB's `reservation_validation_error` returns. Nothing in `backend/`, `tests/` or `frontend/src/` matched on the old string.