### PR TITLE
fix: scope the CustomerSession to the mobile payment element (payments are broken on all clients)

### DIFF
--- a/backend/services/stripe_client.py
+++ b/backend/services/stripe_client.py
@@ -36,9 +36,23 @@ def _to_cents(value) -> int:
 
 
 def _fresh_customer_session(customer_id: str):
+    # "mobile_payment_element", not "payment_element": the latter is the WEB
+    # Elements component. Handing a web-scoped CustomerSession secret to the
+    # mobile PaymentSheet makes its /v1/elements/sessions load fail, which the
+    # SDK surfaces only as the generic code "Failed" ("There was an unexpected
+    # error -- try again in a few seconds"). The real signal is in the device
+    # log: `mc_elements_session_load_failed`.
     return stripe.CustomerSession.create(
         customer=customer_id,
-        components={"payment_element": {"enabled": True}},
+        components={
+            "mobile_payment_element": {
+                "enabled": True,
+                "features": {
+                    "payment_method_save": "enabled",
+                    "payment_method_remove": "enabled",
+                },
+            }
+        },
     )
 
 


### PR DESCRIPTION
**Mobile payments have not worked since #37.** The renter taps Reserve, the Stripe sheet slides up, and it dies before a card can be entered:

> **Error: Failed**
> There was an unexpected error -- try again in a few seconds

## Cause

The CustomerSession was created with the **`payment_element`** component:

```python
stripe.CustomerSession.create(
    customer=customer_id,
    components={"payment_element": {"enabled": True}},   # <- web Elements
)
```

`payment_element` is the **web** Elements component. The mobile PaymentSheet — iOS, Android and React Native alike — requires **`mobile_payment_element`**. Given a web-scoped session secret, the SDK's `/v1/elements/sessions` load is rejected by Stripe and the sheet never becomes usable.

## Why it survived this long

The SDK collapses this into the generic error code `Failed` with that same vague string, which reads exactly like a transient network problem worth retrying. Nothing useful reaches the JS layer — `initPaymentSheet` returns fine, and `presentPaymentSheet` just says `Failed`.

The real signal is only in the device log, and you have to know to look:

| | analytics events |
|---|---|
| **before** | `mc_elements_session_load_failed` → `mc_load_failed` |
| **after** | `mc_confirm_button_tapped` → `paymenthandler.confirm.started` → `confirm.finished` → `mc_complete_payment_newpm_success` |

Both failures fired in under 1.5s, so it isn't a timeout — it's a clean API rejection.

## Verification

End to end on an iOS dev build (simulator), against real Supabase and Stripe test mode:

```
22:02:30  POST create-booking-payment   200
22:02:52  mc_complete_payment_newpm_success
22:02:55  POST finalize-booking         200
```

A one-hour booking on a $2.75/hr listing charged **$3.16**, and the reservation, its conversation, and the first chat message were all created. The identical booking fails on this commit's parent — I reproduced both directions by swapping only this function.

## ⚠️ This is not iOS-specific

The `/v1/elements/sessions` call is made by the Android SDK too, so **Android cannot have worked either**. Any earlier "payments work locally" predates this code path. Worth re-testing on Android before launch rather than assuming this PR only affects iOS.

## Notes

- The `features` block (`payment_method_save` / `payment_method_remove`) is what enables saved-card reuse for returning renters — the reason the CustomerSession exists at all.
- No CI on this PR; the workflow isn't on `main` yet (#62 → #63 brings it). Verification is the trace above.
- Unrelated but found while getting an iOS build running: `.gitignore`'s `/ios` and `/android` rules anchor to the repo root, so the native projects `expo prebuild` generates under `frontend/` land as untracked files. Two lines, happy to send separately.