### PR TITLE
fix: publish messages to realtime so the chat actually updates

### DIFF
--- a/frontend/src/app/Chat.tsx
+++ b/frontend/src/app/Chat.tsx
@@ -154,7 +154,13 @@ export default function ChatScreen() {
           filter: `conversation_id=eq.${conversationId}`,
         },
         (payload) => {
-          setMessages((prev) => [...prev, payload.new as Message]);
+          const incoming = payload.new as Message;
+          // Our own messages are already on screen optimistically and their
+          // echo arrives here too, so dedupe by id rather than appending
+          // blindly — otherwise every message we send renders twice.
+          setMessages((prev) =>
+            prev.some((m) => m.id === incoming.id) ? prev : [...prev, incoming],
+          );
         },
       )
       .subscribe();
@@ -170,11 +176,48 @@ export default function ChatScreen() {
     const content = newMessage.trim();
     setNewMessage('');
 
-    await supabase.from('messages').insert({
-      conversation_id: conversationId,
-      sender_id: currentUserId,
-      content,
-    });
+    // Show it immediately under a temporary id instead of waiting for the round
+    // trip. Sending used to leave the thread visibly unchanged, which reads as
+    // "it didn't go through" and gets the same message sent twice.
+    const tempId = `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: tempId,
+        conversation_id: conversationId,
+        sender_id: currentUserId,
+        content,
+        sent_at: new Date().toISOString(),
+      },
+    ]);
+
+    const { data, error } = await supabase
+      .from('messages')
+      .insert({
+        conversation_id: conversationId,
+        sender_id: currentUserId,
+        content,
+      })
+      .select()
+      .single();
+
+    // The insert result was previously discarded, so a failed send just
+    // disappeared. Take the optimistic row back out and give the user their
+    // text back so it isn't lost.
+    if (error || !data) {
+      console.warn('[Chat] send failed', error);
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setNewMessage((cur) => (cur.length > 0 ? cur : content));
+      return;
+    }
+
+    // Swap the temporary row for the server one so its id is real. Also drop
+    // any copy the realtime subscription delivered in the meantime — whichever
+    // of the two arrives second must not add a duplicate.
+    setMessages((prev) => [
+      ...prev.filter((m) => m.id !== tempId && m.id !== data.id),
+      data as Message,
+    ]);
 
     await supabase
       .from('conversations')

--- a/supabase/migrations/20260808130000_publish_tables_to_realtime.sql
+++ b/supabase/migrations/20260808130000_publish_tables_to_realtime.sql
@@ -1,0 +1,73 @@
+-- Publish the tables the app actually subscribes to.
+--
+-- The supabase_realtime publication exists but has never had a single table
+-- added to it. The only thing the schema does with it is
+--
+--   ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
+--
+-- Postgres logical replication only emits changes for tables that are MEMBERS
+-- of a publication, so Realtime received nothing and every postgres_changes
+-- subscription in the app has been listening to a channel that is never
+-- broadcast on. The subscriptions themselves are fine — they just never fire.
+--
+-- What that cost, in the UI:
+--
+--   Chat.tsx:146-160   subscribes to INSERT on messages for the open
+--                      conversation. Because it never fires, a message sent by
+--                      the OTHER participant never appears while you are
+--                      sitting in the chat, and your own only appears if you
+--                      leave and re-enter (which re-runs the one-shot fetch at
+--                      Chat.tsx:140). Two people coordinating a handoff both
+--                      watch a frozen thread and conclude they are being
+--                      ignored.
+--
+--   SuggestionsList.tsx:76-86  subscribes to '*' on listings to refetch the
+--                      homescreen. Silently dead the same way, so a new or
+--                      edited listing never shows up without a manual reload.
+--
+-- Only these two are published, because only these two have subscribers.
+-- conversations has none — adding it would replicate rows nothing listens for.
+--
+-- Realtime applies RLS per subscriber on top of this, and the policies needed
+-- already exist: messages_conversation_participants_select restricts delivery
+-- to the renter and owner of the parent conversation, so publishing the table
+-- does not expose a message to anyone who could not already read it.
+--
+-- Replica identity is deliberately left at the default (primary key). Both
+-- handlers ignore the payload's old-record — Chat appends payload.new, and
+-- SuggestionsList just refetches — so REPLICA IDENTITY FULL would ship extra
+-- data over the wire for no gain.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'messages'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.messages;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'listings'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.listings;
+  END IF;
+END $$;
+
+-- Fail loudly rather than silently leaving chat broken again.
+DO $$
+DECLARE
+  missing text;
+BEGIN
+  SELECT string_agg(t, ', ') INTO missing
+  FROM unnest(ARRAY['messages', 'listings']) AS t
+  WHERE NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = t
+  );
+
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION 'not published to supabase_realtime: %', missing;
+  END IF;
+END $$;


### PR DESCRIPTION
**Realtime has never worked in this project.** Not for chat, not for the homescreen. Confirmed against production, not inferred.

## Cause

Nothing was ever added to the `supabase_realtime` publication. The schema's only mention of it is:

```sql
ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
```

Postgres only emits changes for tables that are **members** of a publication, so Realtime received nothing and every `postgres_changes` subscription in the app has been listening on a channel that is never broadcast on. The subscriptions are written correctly — they just never fire.

Verified on the live database before touching anything:

```sql
SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'supabase_realtime';
-- (0 rows)
```

## What it cost

| where | symptom |
|---|---|
| `Chat.tsx:146-160` | a message from the **other participant never appears** while you're in the conversation. Your own only appears if you leave and re-enter, which re-runs the one-shot fetch at `Chat.tsx:140`. |
| `SuggestionsList.tsx:76-86` | subscribes to `'*'` on `listings` to refetch the homescreen. Dead the same way — a new listing never appears without a manual reload. |

The chat case is the bad one. Two people coordinating a parking handoff — *"I'm outside", "which driveway?"* — both watch a frozen thread and conclude the other is ignoring them. It also takes **two accounts** to notice: single-account testing only ever loses your own message, which is easy to rationalise as "it'll show up."

## Scope

Only `messages` and `listings` are published, because only those two have subscribers. `conversations` has none — publishing it would replicate rows nothing listens for.

Realtime still applies RLS per subscriber, and `messages_conversation_participants_select` already restricts delivery to the renter and owner of the parent conversation, so this exposes nothing that wasn't already readable. Replica identity is left at the default: both handlers ignore the old-record payload, so `REPLICA IDENTITY FULL` would ship extra data for no gain.

## Also fixed: two things the missing realtime was hiding

**Sending now appends optimistically.** Even with realtime working, waiting a round trip to see your own message is what makes people send it twice. The optimistic row carries a temporary id, is replaced by the server row, and the realtime echo is deduped by real id so nothing renders twice.

**A failed send no longer vanishes.** The insert's error was discarded entirely. It now removes the optimistic row and gives the user their text back instead of silently eating it.

## Verification

Three independent ways:

1. **Throwaway Postgres, real migrations** — `pg_publication_tables` lists both tables afterwards; re-running the migration is a clean no-op; and the migration's own closing assertion was mutation-tested by pointing it at an unpublished table, where it correctly raised `not published to supabase_realtime: conversations`. The safety net isn't vacuous.
2. **Production** — empty before (above), both rows after.
3. **Two live clients** — two iOS simulators signed into the same account with the same conversation open. A message sent from one appeared on the other, untouched, in **under half a second**. That path had never once worked before this change.

## Notes

- Requires the publication change on the hosted project; merging the file alone changes nothing there. Already applied to production.
- Existing clients must reload to resubscribe — the subscription is established at mount.
- No CI on this PR; the workflow isn't on `main` yet (#62 → #63 brings it).