### PR TITLE
fix: enforce the availability window (B3), and stop the clock freezing at mount

### DIFF
--- a/backend/services/stripe_client.py
+++ b/backend/services/stripe_client.py
@@ -243,11 +243,19 @@ def create_booking_payment(listing_id: str, renter_id: str, vehicle_id: str,
         return jsonify({"error": f"Database error: {str(e)}"}), 500
 
     hold_row = hold_result.data[0] if hold_result.data else {}
-    if hold_row.get("error_message") == "slot_unavailable":
+    hold_error = hold_row.get("error_message")
+    if hold_error == "slot_unavailable":
         return jsonify({
             "error": "This spot is being booked right now. Try again in a few minutes.",
             "code": "slot_unavailable",
         }), 409
+    if hold_error:
+        # acquire_booking_hold now also refuses bookings outside the listing's
+        # availability window and ones starting in the past, and returns the
+        # reason as text. Surface it: falling through to the generic 500 below
+        # would tell the renter "Could not hold this slot" when the real answer
+        # is "this spot isn't available until March 3rd".
+        return jsonify({"error": hold_error, "code": "invalid_booking"}), 400
     hold_id = hold_row.get("hold_id")
     if not hold_id:
         return jsonify({"error": "Could not hold this slot"}), 500

--- a/frontend/src/app/search.tsx
+++ b/frontend/src/app/search.tsx
@@ -1307,8 +1307,31 @@ function BookingView({
 }) {
   const router = useRouter();
 
-  // Mount-time anchor — minutes captured once, never drifts with wall clock.
+  // Mount-time anchor. Still frozen ON PURPOSE, but now only for Schedule mode,
+  // which borrows its minutes from it (see the booking-math memo below) — a
+  // scheduled start must not drift under the user while they pick an hour.
   const mountTime = useMemo(() => new Date(), []);
+
+  // "Now", re-derived on a timer. Current-mode bookings and the picker's floor
+  // read this instead of the frozen anchor.
+  //
+  // Both used to read mountTime, which was captured once and never refreshed.
+  // Everything downstream derived from it — the default hour, the earliest
+  // bookable instant, the summary line, the price — so they all stayed
+  // consistent with each other while drifting into the past together, which is
+  // exactly why nothing on screen ever looked wrong. Sit on the booking sheet
+  // for two minutes deciding and you booked a slot that started two minutes
+  // ago, paying for time already gone. The exposure had no upper bound: it was
+  // however long the screen stayed open.
+  //
+  // 15s is far below the smallest bookable unit, so the displayed time is never
+  // meaningfully stale, and one interval is cheap enough to leave running for
+  // the life of the screen.
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 15_000);
+    return () => clearInterval(id);
+  }, []);
 
   // Listings that are reserved right now / not yet started get a locked Current
   // tab and a Schedule mode pre-seeded to next-available. Computed once at mount
@@ -1320,9 +1343,12 @@ function BookingView({
     return `Not available currently, but you can schedule after ${formatSmartWhen(nextAvailableAt)}.`;
   }, [nextAvailableAt]);
 
-  // "Earliest bookable" anchor — replaces mountTime for start-time initialization
+  // "Earliest bookable" anchor — replaces `now` for start-time initialization
   // whenever the listing is currently locked (reserved / not-yet-started).
-  const earliestStart = unavailableNow ? nextAvailableAt! : mountTime;
+  // Reads the ticking `now` so the floor actually advances; when it was the
+  // frozen anchor, the picker's own lower bound went stale, which is why the UI
+  // could not stop you selecting a time that had already passed.
+  const earliestStart = unavailableNow ? nextAvailableAt! : now;
 
   // ─── Booking-mode state (Current is default per Figma) ───────────────────
   const [bookingMode, setBookingMode] = useState<'current' | 'schedule'>('current');
@@ -1485,16 +1511,20 @@ function BookingView({
   // ─── Derived booking math ───────────────────────────────────────────────
   const { startDateTime, endDateTime, hoursBooked } = useMemo(() => {
     if (bookingMode === 'current') {
-      const start = mountTime;
+      // Copy rather than hand out `now` itself: this is returned as
+      // startDateTime, and the schedule branch below mutates its own start with
+      // setHours — one careless edit away from corrupting the shared clock.
+      const start = new Date(now);
       const end = new Date(start.getTime() + currentHours * 3600 * 1000);
       return { startDateTime: start, endDateTime: end, hoursBooked: currentHours };
     }
-    // schedule
+    // schedule — minutes come from the FROZEN anchor, not the ticking clock, so
+    // a start the user picked stays put instead of creeping forward every 15s.
     const start = new Date(scheduleStart);
     start.setHours(startHour, mountTime.getMinutes(), 0, 0);
     const end = new Date(start.getTime() + (endHour - startHour) * 3600 * 1000);
     return { startDateTime: start, endDateTime: end, hoursBooked: endHour - startHour };
-  }, [bookingMode, currentHours, mountTime, scheduleStart, startHour, endHour]);
+  }, [bookingMode, currentHours, now, mountTime, scheduleStart, startHour, endHour]);
 
   // ─── Summary line ───────────────────────────────────────────────────────
   const sameDay =

--- a/supabase/migrations/20260808140000_enforce_availability_window.sql
+++ b/supabase/migrations/20260808140000_enforce_availability_window.sql
@@ -1,0 +1,199 @@
+-- Enforce a listing's availability window, and stop bookings starting in the past.
+--
+-- available_from / available_until were read in exactly one place —
+-- get_visible_listings, which decides what appears on Home and Search. That is
+-- discovery, not enforcement: the date picker clamps to the window, but a direct
+-- API call ignores it entirely. A listing whose window closed on 31 July
+-- accepted, held and finalised a paid, confirmed booking for 10 August, with no
+-- error anywhere in the chain. Because nothing raised, the auto-refund path
+-- never fired either: the owner's stated terms were violated silently, with real
+-- money captured.
+--
+-- Not hypothetical here. 11 of 18 listings carry a window and 9 of those expired
+-- on 31 July, so most of the live data is bookable-but-shouldn't-be today.
+--
+-- ── WHERE EACH RULE GOES, AND WHY IT MATTERS ───────────────────────────────
+--
+-- reservation_validation_error is called TWICE for one booking: once by
+-- create_booking_payment BEFORE the card is charged, and again by the
+-- trg_validate_reservation_rate trigger when the row is inserted, which happens
+-- AFTER payment succeeds. A rule enforced in that function must therefore give
+-- the SAME answer at both moments. If it can flip in between, the booking is
+-- charged and then refused — the exact failure #63 was written to eliminate.
+--
+-- That sorts the two rules in this migration:
+--
+--   Availability window — compares the booking's own start/end against the
+--     listing's window. Nothing about it depends on when it is evaluated, so it
+--     is safe in the shared function and is enforced on both paths.
+--
+--   Start time not in the past — depends on now(), so its answer changes
+--     continuously. Enforced at insert it would reject a Stripe webhook RETRY
+--     arriving minutes or hours later, stranding a renter who paid. It is
+--     therefore enforced ONLY in acquire_booking_hold, which runs before any
+--     PaymentIntent exists, where a rejection costs nothing.
+--
+-- NULL means "no constraint", matching get_visible_listings. Bounds are
+-- inclusive: a booking may start exactly at available_from and end exactly at
+-- available_until.
+
+BEGIN;
+
+-- ── M5: stop bookkeeping updates re-running validation ─────────────────────
+-- The trigger fired on INSERT OR UPDATE, so it re-validated on every write to
+-- a reservation — including the payout sweep's payout_status updates. That was
+-- harmless only while every rule depended solely on the listing's rate columns.
+-- Adding an availability rule re-arms it: a booking made inside a window, then
+-- updated by the sweep after that window closes, would start failing, blocking
+-- payouts and opening a second route into the pay-then-refund loss.
+--
+-- Narrowed to the columns the rules actually read. UPDATE OF fires only when a
+-- statement mentions one of these, so payout_status bookkeeping no longer
+-- triggers validation, while a genuine reschedule still does.
+DROP TRIGGER IF EXISTS trg_validate_reservation_rate ON public.reservations;
+CREATE TRIGGER trg_validate_reservation_rate
+BEFORE INSERT OR UPDATE OF listing_id, start_time, end_time ON public.reservations
+FOR EACH ROW EXECUTE FUNCTION public.validate_reservation_rate();
+
+-- ── B3: the window becomes a rule, not a display hint ──────────────────────
+CREATE OR REPLACE FUNCTION public.reservation_validation_error(
+  p_listing_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz
+) RETURNS text AS $$
+DECLARE
+  listing_row RECORD;
+  effective_hourly numeric;
+BEGIN
+  IF p_end_time <= p_start_time THEN
+    RETURN 'end_time must be after start_time';
+  END IF;
+
+  SELECT * INTO listing_row FROM public.listings WHERE id = p_listing_id;
+  IF NOT FOUND THEN
+    RETURN 'Listing not found';
+  END IF;
+
+  -- Same precedence as pricing.calculate_final_price: hourly_rate wins, then
+  -- the legacy price_per_hour column.
+  effective_hourly := COALESCE(listing_row.hourly_rate, listing_row.price_per_hour);
+
+  -- Reject only what the pricing engine itself would refuse to price. Any
+  -- duration is bookable as long as SOME rate exists: the engine selects the
+  -- cheapest applicable tier and caps hourly runs at the daily rate when set.
+  IF effective_hourly IS NULL
+     AND listing_row.daily_rate IS NULL
+     AND listing_row.weekly_rate IS NULL
+     AND listing_row.monthly_rate IS NULL
+  THEN
+    RETURN 'No rates available for this listing';
+  END IF;
+
+  -- The owner's stated availability. NULL on either side means unbounded.
+  -- Time-invariant: this compares the booking to the listing, never to now(),
+  -- so it cannot flip between the pre-charge call and the insert-time one.
+  IF listing_row.available_from IS NOT NULL
+     AND p_start_time < listing_row.available_from THEN
+    RETURN 'This spot is not available until '
+           || to_char(listing_row.available_from, 'Mon DD, YYYY');
+  END IF;
+
+  IF listing_row.available_until IS NOT NULL
+     AND p_end_time > listing_row.available_until THEN
+    RETURN 'This spot is only available until '
+           || to_char(listing_row.available_until, 'Mon DD, YYYY');
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION public.reservation_validation_error(uuid, timestamptz, timestamptz) IS
+  'Single source of truth for "may this reservation exist". Returns NULL if allowed, else the reason. Called by the validate_reservation_rate trigger (which raises it) AND by the backend before creating a PaymentIntent, so no rule can reject a booking only after the renter has been charged. Every rule here MUST be time-invariant: it is evaluated once before payment and again at insert, and a rule whose answer changes in between strands a paid renter. Rules that depend on now() belong in acquire_booking_hold instead.';
+
+GRANT EXECUTE ON FUNCTION public.reservation_validation_error(uuid, timestamptz, timestamptz)
+  TO authenticated, service_role, anon;
+
+-- ── The hold refuses the same bookings, earlier and more cheaply ───────────
+-- acquire_booking_hold runs on Reserve-press, before any Stripe object exists,
+-- so a rejection here costs nothing at all. It carries both the shared rules
+-- and the now()-dependent one that must never reach the trigger.
+CREATE OR REPLACE FUNCTION public.acquire_booking_hold(
+    p_listing_id UUID,
+    p_renter_id UUID,
+    p_vehicle_id UUID,
+    p_start_time TIMESTAMPTZ,
+    p_end_time TIMESTAMPTZ,
+    p_ttl_minutes INT DEFAULT 5
+)
+RETURNS TABLE(hold_id UUID, expires_at TIMESTAMPTZ, error_message TEXT) AS $$
+DECLARE
+    v_hold_id UUID;
+    v_expires TIMESTAMPTZ;
+    v_validation_error TEXT;
+BEGIN
+    -- Shared rules first: rates, ordering, and the availability window.
+    v_validation_error := public.reservation_validation_error(
+        p_listing_id, p_start_time, p_end_time
+    );
+    IF v_validation_error IS NOT NULL THEN
+        RETURN QUERY SELECT NULL::UUID, NULL::TIMESTAMPTZ, v_validation_error;
+        RETURN;
+    END IF;
+
+    -- Then the rule that may not live in the shared function. The client freezes
+    -- start_time when the booking screen mounts and never refreshes it, so a
+    -- renter who sits on that screen books further and further into the past and
+    -- pays for time they cannot use. The tolerance is deliberate rather than
+    -- zero: start_time is captured before checkout, so a few minutes of drift is
+    -- ordinary. This is a backstop against booking retroactively, not a
+    -- precision clock — the display accuracy is fixed client-side.
+    IF p_start_time < now() - INTERVAL '15 minutes' THEN
+        RETURN QUERY SELECT NULL::UUID, NULL::TIMESTAMPTZ,
+            'This booking would start in the past. Please pick a new time.'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Serialize all hold activity for this listing.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_listing_id::text, 0));
+
+    -- Clear expired holds for this listing so they don't block new ones.
+    -- Qualify expires_at: the OUT column of the same name would be ambiguous.
+    DELETE FROM public.reservation_holds
+     WHERE listing_id = p_listing_id AND reservation_holds.expires_at <= now();
+
+    -- Re-pressing Reserve replaces this renter's own prior hold on this listing.
+    DELETE FROM public.reservation_holds
+     WHERE listing_id = p_listing_id AND renter_id = p_renter_id;
+
+    -- Conflict with another renter's live hold?
+    IF EXISTS (
+        SELECT 1 FROM public.reservation_holds h
+         WHERE h.listing_id = p_listing_id
+           AND tstzrange(h.start_time, h.end_time) && tstzrange(p_start_time, p_end_time)
+    ) THEN
+        RETURN QUERY SELECT NULL::UUID, NULL::TIMESTAMPTZ, 'slot_unavailable'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Conflict with an existing (non-cancelled) reservation?
+    IF EXISTS (
+        SELECT 1 FROM public.reservations r
+         WHERE r.listing_id = p_listing_id
+           AND r.status <> 'cancelled'
+           AND tstzrange(r.start_time, r.end_time) && tstzrange(p_start_time, p_end_time)
+    ) THEN
+        RETURN QUERY SELECT NULL::UUID, NULL::TIMESTAMPTZ, 'slot_unavailable'::TEXT;
+        RETURN;
+    END IF;
+
+    v_expires := now() + make_interval(mins => p_ttl_minutes);
+    INSERT INTO public.reservation_holds (listing_id, renter_id, vehicle_id, start_time, end_time, expires_at)
+    VALUES (p_listing_id, p_renter_id, p_vehicle_id, p_start_time, p_end_time, v_expires)
+    RETURNING id INTO v_hold_id;
+
+    RETURN QUERY SELECT v_hold_id, v_expires, NULL::TEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
> **Stacked on #63** (base is `ci/automated-checks`, not `main`) because `reservation_validation_error` only exists there. Merge order: #62 → #63 → this. The diff shown is only my changes.

Two bugs that turn out to share a fix site, plus the trigger change that makes either of them safe to add at all.

## B3 — availability dates were enforced nowhere

`available_from` / `available_until` were read in exactly one place: `get_visible_listings`, which decides what appears on Home and Search. That's *discovery*, not enforcement. The date picker clamps to the window, but a direct API call ignores it entirely.

A listing whose window closed on 31 July accepted, held, and finalised a paid, confirmed booking for 10 August with no error anywhere in the chain. Because nothing raised, the auto-refund path never fired either — the owner's stated terms were violated silently, with real money captured.

**Not hypothetical.** 11 of the 18 live listings carry a window, and 9 of those expired on 31 July.

## The frozen clock

The booking screen captured "now" once:

```js
const mountTime = useMemo(() => new Date(), []);   // never refreshed
```

Everything downstream read from it — the default hour, the picker's floor, the summary line, the price. So they all stayed consistent *with each other* while drifting into the past *together*, which is exactly why nothing on screen ever looked wrong. Sit on the sheet for two minutes deciding, and you booked a slot that started two minutes ago and paid for time already gone. No upper bound: the exposure was however long the screen stayed open.

Same root cause as **H5**, where the identical defect shows up instead as the "reservation starting" notification never firing for book-now bookings.

## Where each rule goes — the part that matters

`reservation_validation_error` is called **twice** for one booking: once before the card is charged, and again by the insert trigger *after* payment succeeds. A rule living there must give the same answer at both moments, or the booking is charged and then refused — the failure #63 exists to prevent.

| rule | placed in | reasoning |
|---|---|---|
| availability window | shared function **+** `acquire_booking_hold` | compares the booking to the listing, never to `now()` — cannot flip in between |
| start not in the past | `acquire_booking_hold` **only** | depends on `now()`. At insert it would reject a Stripe **webhook retry** arriving minutes later and strand a paid renter |

The past-start tolerance is 15 minutes: a backstop against retroactive booking, not a precision clock. Accuracy is the client's job.

## M5 is load-bearing here, and I proved it

The trigger fired `BEFORE INSERT OR UPDATE` — re-validating on *every* write, including the payout sweep's `payout_status` bookkeeping. Harmless while every rule read only rate columns. Adding an availability rule re-arms it:

```
── restore the OLD broad trigger, then retry the same sweep update
ERROR:  This spot is only available until Aug 09, 2026
CONTEXT: PL/pgSQL function validate_reservation_rate() line 9 at RAISE
```

That's a plain `payout_status` update on a booking whose window has since lapsed. Payouts would have broken the moment this shipped, opening a second route into B5's pay-then-refund loss. Narrowed to `UPDATE OF listing_id, start_time, end_time`, so bookkeeping no longer validates while a genuine reschedule still does.

## Verification

Throwaway Postgres against the real migrations, asserting each rule at **every call site separately** — three different code paths, and one passing proves nothing about the others:

| | result |
|---|---|
| pre-charge RPC, outside window | refused, both directions and straddling |
| pre-charge RPC, inside / on bounds / no window | allowed — bounds inclusive, NULL unbounded |
| pre-charge RPC, past start | **not** refused (correct — would strand a retry) |
| hold, outside window / past start | refused |
| hold, 2min drift | allowed |
| insert trigger, outside window | raises |
| sweep `payout_status` update | succeeds |
| genuine reschedule | still raises |

**Mutation-checked** by dropping the migration: the out-of-window booking is then validated clean, held, **and inserted** — B3 reproduced exactly as reported.

## Residual, deliberately not closed

The tick makes `start_time` current as of Reserve-press, but checkout still takes time, so a renter still loses the seconds between pressing Reserve and completing payment. Closing that fully means the backend stamping `start = now()` at PaymentIntent creation — a client/server contract change that deserves its own review rather than riding along here.

## Notes

- The frozen anchor is **kept on purpose** for Schedule mode, which borrows its minutes and must not creep forward while the user picks an hour.
- `acquire_booking_hold` can now return a reason other than `slot_unavailable`, so the backend surfaces it as 400 rather than falling through to "Could not hold this slot".
- Unrelated, found while running this: `test_create_reservation_basic` omits `vehicle_id`, required since #55. It's been failing silently because it only runs against a live backend — and CI has none, so all 4 integration tests skip there. "47 passed, 4 skipped" has been hiding four tests that never execute.