### PR TITLE
fix: retry a deadlocked finalize instead of stranding the payment (B6)

### DIFF
--- a/backend/services/stripe_client.py
+++ b/backend/services/stripe_client.py
@@ -1,6 +1,8 @@
 import os
 import json
+import random
 import re
+import time
 import traceback
 import stripe
 from flask import jsonify
@@ -97,6 +99,21 @@ def _reservation_validation_error(listing_id: str, start_time: str, end_time: st
 _TERMINAL_ERROR_PREFIXES = ("slot_unavailable", "missing_metadata")
 
 
+# Class 40 is "transaction rollback" — 40P01 deadlock_detected, 40001
+# serialization_failure. These mean "your transaction lost a race and was rolled
+# back", which is genuinely retryable: the same call usually succeeds moments
+# later. They are handled by re-calling the RPC (see _FINALIZE_MAX_ATTEMPTS
+# below), not by classification.
+_RETRYABLE_DB_ERROR = re.compile(r"^db_40[0-9A-Z]{3}:")
+
+# How many times to re-call finalize_paid_reservation on a class-40 error.
+# Deliberately small and fast: this runs inside a Stripe webhook handler, which
+# wants a prompt ACK, and deadlocks resolve the instant the victim rolls back.
+# Too generous and Stripe times out and retries the whole webhook on top of us.
+_FINALIZE_MAX_ATTEMPTS = 3
+_FINALIZE_RETRY_DELAY = (0.05, 0.15)  # jittered, so two racers don't re-collide
+
+
 def _is_terminal_finalize_error(message: str) -> bool:
     if not message:
         return False
@@ -105,7 +122,14 @@ def _is_terminal_finalize_error(message: str) -> bool:
     # SQLSTATEs are 5 alphanumeric chars, not 5 digits: class 23 includes 23505
     # (unique), 23503 (FK) AND 23P01 (exclusion — the double-booking one), so a
     # \d{3} tail silently missed exactly the case that matters most here.
-    return bool(re.match(r"^db_(P0001|23[0-9A-Z]{3}):", message))
+    if re.match(r"^db_(P0001|23[0-9A-Z]{3}):", message):
+        return True
+    # A class-40 error only reaches classification once the retries above are
+    # exhausted. Treat it as terminal at that point: the renter's money must not
+    # depend on a later retry that nothing performs. Nothing re-drives a
+    # non-terminal failure — the webhook ACKs 200 regardless and there is no
+    # reconciliation sweep — so "retryable" here means "silently stranded".
+    return bool(_RETRYABLE_DB_ERROR.match(message))
 
 
 def _refund_stranded_payment(payment_intent_id: str, reason: str) -> str:
@@ -476,26 +500,60 @@ def _finalize_reservation_from_pi(pi) -> dict:
             "p_charge_id": str(charge) if charge else None,
         }
 
-        try:
-            result = supabase.rpc("finalize_paid_reservation", params).execute()
-        except Exception as err:  # noqa: BLE001
-            print(f"[stripe] finalize_paid_reservation RPC raised: {err}")
-            traceback.print_exc()
-            return {"error": f"db_error: {err}"}
+        # Retry on class-40 (deadlock / serialization) failures.
+        #
+        # Two renters racing OVERLAPPING — not identical — ranges on one listing
+        # both reach a succeeded payment, and both call this. Measured against
+        # the real function over 30 concurrent trials, the loser came back
+        # 'slot_unavailable' half the time and 'db_40P01: deadlock detected' the
+        # other half. Only the first is terminal, so half of all losing renters
+        # were charged, given no reservation, and never refunded — recoverable
+        # only by a human reading a log line.
+        #
+        # Retrying is the right response rather than reclassifying, because it
+        # produces the correct outcome for BOTH racers instead of just refunding
+        # more people: on the retry one renter wins the slot and the other gets a
+        # clean exclusion violation, which is already terminal and already
+        # refunds. It also fixes the milder case where the client and the webhook
+        # deadlock over the SAME payment — the retry finds the row the other one
+        # just created (finalize_paid_reservation checks stripe_payment_intent
+        # before inserting, so this is safe) and returns success, instead of
+        # showing the renter "charged, contact support" for a booking that exists.
+        #
+        # Both callers — the webhook and the client-invoked finalize — come
+        # through here, so one retry site covers both.
+        for attempt in range(1, _FINALIZE_MAX_ATTEMPTS + 1):
+            try:
+                result = supabase.rpc("finalize_paid_reservation", params).execute()
+            except Exception as err:  # noqa: BLE001
+                print(f"[stripe] finalize_paid_reservation RPC raised: {err}")
+                traceback.print_exc()
+                return {"error": f"db_error: {err}"}
 
-        data = getattr(result, "data", None)
-        print(f"[stripe] finalize_paid_reservation returned data={data!r}")
+            data = getattr(result, "data", None)
+            print(f"[stripe] finalize_paid_reservation returned data={data!r}")
 
-        if not data:
-            return {"error": "rpc_empty_response"}
+            if not data:
+                return {"error": "rpc_empty_response"}
 
-        # RETURNS TABLE → list of rows; occasionally scalar depending on client.
-        row = data[0] if isinstance(data, list) else data
-        if not isinstance(row, dict):
-            return {"error": f"rpc_unexpected_shape: {type(row).__name__}"}
+            # RETURNS TABLE → list of rows; occasionally scalar depending on client.
+            row = data[0] if isinstance(data, list) else data
+            if not isinstance(row, dict):
+                return {"error": f"rpc_unexpected_shape: {type(row).__name__}"}
 
-        if row.get("error_message"):
-            return {"error": row["error_message"]}
+            error_message = row.get("error_message")
+            if error_message:
+                if (_RETRYABLE_DB_ERROR.match(error_message)
+                        and attempt < _FINALIZE_MAX_ATTEMPTS):
+                    print(f"[stripe] finalize attempt {attempt} lost a race "
+                          f"({error_message}); retrying")
+                    time.sleep(random.uniform(*_FINALIZE_RETRY_DELAY))
+                    continue
+                # Either terminal, or class-40 with no attempts left — in which
+                # case _is_terminal_finalize_error now treats it as terminal so
+                # the capture is refunded rather than silently stranded.
+                return {"error": error_message}
+            break
 
         rid = row.get("reservation_id")
         if not rid:

--- a/tests/backend/test_finalize_deadlock_retry.py
+++ b/tests/backend/test_finalize_deadlock_retry.py
@@ -1,0 +1,170 @@
+"""Deadlocks during finalize must be retried, not silently stranded.
+
+Two renters racing OVERLAPPING (not identical) ranges on one listing both reach
+a succeeded payment and both call finalize. Measured against the real function
+in Postgres over 30 concurrent trials, the loser came back 'slot_unavailable'
+half the time and 'db_40P01: deadlock detected' the other half. Only the first
+was terminal, so half of all losing renters were charged, given no reservation,
+and never refunded.
+
+40P01 is genuinely retryable — the transaction was rolled back and the same call
+usually succeeds moments later — but nothing ever retried it. The webhook ACKs
+200 regardless and there is no reconciliation sweep, so "retryable" meant
+"stranded". These pin both halves of the fix: the retry, and the classification
+that catches whatever survives it.
+
+This class is invisible to a fake database, which is why it went unnoticed: the
+fake never contends. Here the contention is simulated at the RPC boundary; the
+real-Postgres measurement lives in the PR.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+
+@pytest.fixture
+def stripe_client(monkeypatch):
+    """Import services.stripe_client with its heavy deps stubbed out."""
+    for name, attrs in {
+        "services.supabase_client": {"supabase": types.SimpleNamespace()},
+        "services.payouts": {"_parse_ts": lambda *_a: None,
+                             "release_pending_for_account": lambda *_a: 0},
+        "services.notifications": {"send_booking_notifications": lambda *_a: {}},
+    }.items():
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.delitem(sys.modules, "services.stripe_client", raising=False)
+    import services.stripe_client as sc
+    # Never actually sleep between attempts — the delay is real-world jitter,
+    # not behaviour under test, and three of them would slow the suite.
+    # Guarded so that reverting the fix makes these tests FAIL on their
+    # assertions rather than ERROR in setup: an error can't tell you whether the
+    # behaviour regressed or the module merely changed shape.
+    if hasattr(sc, "time"):
+        monkeypatch.setattr(sc.time, "sleep", lambda _s: None)
+    return sc
+
+
+PI = {
+    "id": "pi_test_123",
+    "latest_charge": "ch_test_123",
+    "metadata": {
+        "listing_id": "11111111-1111-1111-1111-111111111111",
+        "renter_id": "22222222-2222-2222-2222-222222222222",
+        "vehicle_id": "33333333-3333-3333-3333-333333333333",
+        "start_time": "2026-08-10T09:00:00Z",
+        "end_time": "2026-08-10T10:00:00Z",
+        "total_price": "11.50",
+        "platform_fee": "1.50",
+        "host_payout": "10.00",
+    },
+}
+
+DEADLOCK = "db_40P01: deadlock detected"
+
+
+class _ScriptedRpc:
+    """Returns a queued row per call, recording how many times it was invoked."""
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.calls = 0
+
+    def __call__(self, _name, _params):
+        self.calls += 1
+        row = self.rows[min(self.calls - 1, len(self.rows) - 1)]
+        return types.SimpleNamespace(execute=lambda: types.SimpleNamespace(data=[row]))
+
+
+def _ok(rid="44444444-4444-4444-4444-444444444444"):
+    return {"reservation_id": rid, "error_message": None}
+
+
+def _err(message):
+    return {"reservation_id": None, "error_message": message}
+
+
+# ── classification ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("message", [
+    "db_40P01: deadlock detected",          # the measured one
+    "db_40001: could not serialize access",
+])
+def test_class_40_is_terminal_once_retries_are_exhausted(stripe_client, message):
+    """Nothing re-drives a non-terminal failure, so leaving these 'retryable'
+    means the renter is charged and never refunded."""
+    assert stripe_client._is_terminal_finalize_error(message) is True
+
+
+def test_connection_errors_stay_retryable(stripe_client):
+    """Unlike a deadlock, a dropped connection may have committed the insert —
+    refunding could cancel a booking that exists."""
+    assert stripe_client._is_terminal_finalize_error("db_08006: could not connect") is False
+
+
+# ── the retry ─────────────────────────────────────────────────────────────────
+
+def test_deadlock_is_retried_and_succeeds(stripe_client, monkeypatch):
+    """The common case: the racer that lost retries and gets its reservation."""
+    rpc = _ScriptedRpc([_err(DEADLOCK), _ok()])
+    monkeypatch.setattr(stripe_client.supabase, "rpc", rpc, raising=False)
+
+    outcome = stripe_client._finalize_reservation_from_pi(PI)
+
+    assert rpc.calls == 2
+    assert outcome == {"reservation_id": "44444444-4444-4444-4444-444444444444"}
+
+
+def test_retry_finds_the_row_the_other_racer_created(stripe_client, monkeypatch):
+    """Client and webhook deadlocking over the SAME payment: finalize checks
+    stripe_payment_intent before inserting, so the retry returns the existing
+    reservation instead of showing 'charged, contact support' for a booking
+    that already exists."""
+    rpc = _ScriptedRpc([_err(DEADLOCK), _ok("55555555-5555-5555-5555-555555555555")])
+    monkeypatch.setattr(stripe_client.supabase, "rpc", rpc, raising=False)
+
+    outcome = stripe_client._finalize_reservation_from_pi(PI)
+
+    assert outcome["reservation_id"] == "55555555-5555-5555-5555-555555555555"
+
+
+def test_persistent_deadlock_gives_up_and_is_refundable(stripe_client, monkeypatch):
+    """Exhausted retries must surface a TERMINAL error so the capture is given
+    back, rather than a retryable one that nothing ever retries."""
+    rpc = _ScriptedRpc([_err(DEADLOCK)])
+    monkeypatch.setattr(stripe_client.supabase, "rpc", rpc, raising=False)
+
+    outcome = stripe_client._finalize_reservation_from_pi(PI)
+
+    assert rpc.calls == stripe_client._FINALIZE_MAX_ATTEMPTS
+    assert outcome["error"] == DEADLOCK
+    assert stripe_client._is_terminal_finalize_error(outcome["error"]) is True
+
+
+def test_the_loser_of_a_real_race_is_not_retried(stripe_client, monkeypatch):
+    """slot_unavailable is a decision, not a collision. Retrying it would just
+    delay the refund the renter is owed."""
+    rpc = _ScriptedRpc([_err("slot_unavailable")])
+    monkeypatch.setattr(stripe_client.supabase, "rpc", rpc, raising=False)
+
+    outcome = stripe_client._finalize_reservation_from_pi(PI)
+
+    assert rpc.calls == 1
+    assert outcome["error"] == "slot_unavailable"
+
+
+def test_success_does_not_retry(stripe_client, monkeypatch):
+    rpc = _ScriptedRpc([_ok()])
+    monkeypatch.setattr(stripe_client.supabase, "rpc", rpc, raising=False)
+
+    stripe_client._finalize_reservation_from_pi(PI)
+
+    assert rpc.calls == 1


### PR DESCRIPTION
> **Stacked on #70** (which is stacked on #63). Full stack: `main ← #62 ← #63 ← #70 ← this`. The diff shown is only my changes.

Closes blocker **B6**.

## Measured, not inferred

Two renters racing **overlapping** — not identical — ranges on one listing both reach a succeeded payment, and both call finalize. 30 concurrent trials against the real function in a real Postgres, 60 calls:

| outcome | count | meaning |
|---|---|---|
| `OK` | 30 | one winner per trial — correct |
| `slot_unavailable` | 15 | loser refused cleanly → terminal → **refunded** |
| `db_40P01` | 15 | loser deadlocked → "retryable" → **nothing happens** |

**Half of all losing renters were charged, given no reservation, and never refunded.**

"Retryable" was doing no work. The webhook ACKs 200 regardless, and there is no reconciliation sweep, so nothing ever re-drove those. Recoverable only by a human reading a log line.

## Retry rather than reclassify

The review offered either treating class 40 as terminal *or* retrying. They sound equivalent; they aren't.

Reclassifying refunds **more** people, including the racer who would have won on a retry. Retrying resolves the race properly: one renter takes the slot, the other collides with the exclusion constraint and gets `23P01` — already terminal, already refunded correctly. The right outcome for both, instead of a safer wrong one for both.

Same 30 trials, with the retry:

| outcome | before | after |
|---|---|---|
| `OK` | 30 | 30 |
| `slot_unavailable` (refunded) | 15 | **30** |
| `db_40P01` (stranded) | **15** | **0** |

## It also fixes the second half of the finding

When the client-invoked finalize and the webhook deadlock over the **same** payment, the retry finds the row the other just created and returns success — instead of showing the renter *"your card was charged, contact support"* for a booking that plainly exists. Reclassification would have **refunded** that booking.

**This is only safe because `finalize_paid_reservation` looks up `stripe_payment_intent` before inserting.** I verified that in the function body rather than trusting the comment. Without it, a retry would hit `uq_reservations_payment_intent` → `23505` → classified terminal → refunded, leaving a live reservation with a refunded buyer. That's B5's shape, self-inflicted.

## Details

- **3 attempts, 50–150ms jitter.** Small deliberately: this runs inside a Stripe webhook handler that wants a prompt ACK, deadlocks resolve the instant the victim rolls back, and anything generous risks Stripe timing out and retrying the whole webhook on top of our in-process retries. Jitter stops two racers re-colliding in lockstep.
- **Class 40 becomes terminal only once retries are exhausted**, so a persistent deadlock refunds rather than strands.
- **`08xxx` connection errors stay retryable on purpose.** Unlike a deadlock, a dropped connection may have committed the insert — refunding could cancel a booking that exists.
- **One retry site covers both callers.** The webhook (`_on_payment_succeeded`) and the client finalize (`finalize_booking`) both go through `_finalize_reservation_from_pi`.

## Tests

8 new tests, in a new file, that **run in CI** — the real-Postgres measurement above cannot, because CI has no database. That gap is exactly why this class stayed invisible: a fake database never contends, so no amount of unit testing would have surfaced it.

**Mutation-checked** by restoring the pre-fix module: **5 of 8 fail**. They fail on their assertions rather than erroring in setup — I had to fix my own fixture to achieve that, because an error in setup can't distinguish "the behaviour regressed" from "the module changed shape."

## Known residual

Nothing re-drives `08xxx` or `rpc_empty_response` either, so those remain stranded-but-rare. The honest fix is a reconciliation sweep over captured payments with no reservation, which is its own piece of work rather than something to bolt on here.