### PR TITLE
fix: Initial location displayed and Distance display

### DIFF
--- a/frontend/src/app/CreateListing2.tsx
+++ b/frontend/src/app/CreateListing2.tsx
@@ -221,6 +221,12 @@ export default function CreateListing2() {
     if (showCalendarPopup) openPopup(calendarPopupAnim);
   }, [showCalendarPopup]);
 
+  useEffect(() => {
+    if (scene === 2) {
+      handleCurrentLocation();
+    }
+  }, [scene]);
+
   // ── Price PanResponder ─────────────────────────────────────────────────────
   // Two separate refs so toggling Hourly↔Weekly preserves each value.
   // periodTypeRef mirrors state so the PanResponder (built once via useRef)

--- a/frontend/src/components/HomescreenComponents/DynamicViewer.tsx
+++ b/frontend/src/components/HomescreenComponents/DynamicViewer.tsx
@@ -251,12 +251,6 @@ export default function DynamicViewer({ onFallback }: DynamicViewerProps = {}) {
             {priceStr}
             <Text style={[styles.unitText, { fontSize: FONT_UNIT }]}>{unitStr}</Text>
           </Text>
-          <View style={styles.distRow}>
-            <Ionicons name="walk" size={WALK_ICON} color="#fff" />
-            <Text style={[styles.distText, { fontSize: FONT_DIST }]}>
-              {item.distance.toFixed(1)}mi
-            </Text>
-          </View>
         </View>
 
         {/* Bottom pill — address + yellow navigation arrow */}


### PR DESCRIPTION
Fixed the remaining 2 bugs on the bug page Notion
- Made the initial location the user's current location during listing creation instead of Gainesville.
- Removed the distance display from the nearby listings list on the home screen.